### PR TITLE
freezing master on 0.71.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,14 +119,14 @@ jobs:
           release=false
           if [ "$MASTER_VERSION" = "$VERSION" ] ; then
             echo "$VERSION has been previously released."
-          elif dpkg --compare-versions $VERSION 'gt' '0.32.3' ; then
+          elif [ $VERSION = '0.71.0' ] ; then
             git config user.name "CovalentOpsBot"
             git config user.email "covalentopsbot@users.noreply.github.com"
             git remote set-url origin https://${{ secrets.COVALENT_OPS_BOT_TOKEN }}@github.com/AgnostiqHQ/covalent.git
             git push origin HEAD:master
             release=true
           else
-            echo "We cannot release versions less than 0.32.3."
+            echo "Master is frozen on 0.71.0"
           fi
           echo "RELEASE=$release" >> $GITHUB_ENV
       - name: Format Slack message


### PR DESCRIPTION
I intend to merge this with the red button without updating the version or changelog.

After this is merged I will loosen the branch protection rules for `develop`