### PR TITLE
Re-dispatching workflows: comparing transport graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Added method for comparing two transport graphs to determine reusable nodes
+
 ## [0.155.0] - 2022-07-26
 
 ### Authors

--- a/covalent/_workflow/tgutils.py
+++ b/covalent/_workflow/tgutils.py
@@ -1,0 +1,170 @@
+# Copyright 2021 Agnostiq Inc.
+#
+# This file is part of Covalent.
+#
+# Licensed under the GNU Affero General Public License 3.0 (the "License").
+# A copy of the License may be obtained with this software package or at
+#
+#      https://www.gnu.org/licenses/agpl-3.0.en.html
+#
+# Use of this file is prohibited except in compliance with the License. Any
+# modifications or derivative works of this file must retain this copyright
+# notice, and modified files must contain a notice indicating that they have
+# been altered from the originals.
+#
+# Covalent is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the License for more details.
+#
+# Relief from the License may be granted by purchasing a commercial license.
+
+"""Utility functions for the transport graph"""
+
+from collections import deque
+from enum import Enum
+from typing import Callable
+
+import networkx as nx
+
+from .._shared_files import logger
+
+app_log = logger.app_log
+
+# Utils for diffing transport graphs
+
+_status_map = {1: True, -1: False}
+
+
+def _invalidate_successors(A: nx.MultiDiGraph, node_statuses: dict, starting_node: int):
+    nodes_to_invalidate = [starting_node]
+    for node, successors in nx.bfs_successors(A, starting_node):
+        for child in successors:
+            nodes_to_invalidate.append(child)
+    for node in nodes_to_invalidate:
+        node_statuses[node] = -1
+
+
+def _same_node(A: nx.MultiDiGraph, B: nx.MultiDiGraph, node: int):
+    return A.nodes[node] == B.nodes[node]
+
+
+def _same_edge_attributes(A: nx.MultiDiGraph, B: nx.MultiDiGraph, parent: int, node: int):
+    return A.adj[parent][node] == B.adj[parent][node]
+
+
+def max_cbms(
+    A: nx.MultiDiGraph,
+    B: nx.MultiDiGraph,
+    node_cmp: Callable = _same_node,
+    edge_cmp: Callable = _same_edge_attributes,
+):
+    """Computes a "maximum backward-maximal common subgraph" (cbms)
+
+    Args:
+        A: nx.MultiDiGraph
+        B: nx.MultiDiGraph
+        node_cmp: An optional function for comparing node attributes in A and B.
+                  Defaults to testing for equality of the attribute dictionaries
+        edge_cmp: An optional function for comparing the edges between two nodes.
+                  Defaults to checking that the two sets of edges have the same attributes
+
+    Returns: A_node_status, B_node_status, where each is a dictionary
+        `{node: True/False}` where True means reusable.
+
+    Performs a modified BFS of A and B.
+    """
+
+    A_node_status = {node_id: 0 for node_id in A.nodes}
+    B_node_status = {node_id: 0 for node_id in B.nodes}
+    app_log.debug("A node status:", A_node_status)
+    app_log.debug("B node status:", B_node_status)
+
+    virtual_root = -1
+
+    if virtual_root in A.nodes or virtual_root in B.nodes:
+        raise RuntimeError(f"Encountered forbidden node: {virtual_root}")
+
+    assert virtual_root not in B.nodes
+
+    nodes_to_visit = deque()
+    nodes_to_visit.appendleft(virtual_root)
+
+    # Add a temporary root
+    A_parentless_nodes = [node for node, deg in A.in_degree() if deg == 0]
+    B_parentless_nodes = [node for node, deg in B.in_degree() if deg == 0]
+    for node_id in A_parentless_nodes:
+        A.add_edge(virtual_root, node_id)
+
+    for node_id in B_parentless_nodes:
+        B.add_edge(virtual_root, node_id)
+
+    # Assume inductively that predecessors subgraphs are the same;
+    # this is satisfied for the root
+    while nodes_to_visit:
+        current_node = nodes_to_visit.pop()
+
+        app_log.debug(f"Visiting node {current_node}")
+        for y in A.adj[current_node]:
+            # Don't process already failed nodes
+            if A_node_status[y] == -1:
+                continue
+
+            # Check if y is a valid child of current_node in B
+            if y not in B.adj[current_node]:
+                app_log.debug(f"A: {y} not adjacent to node {current_node} in B")
+                _invalidate_successors(A, A_node_status, y)
+                continue
+
+            if y in B.adj[current_node] and B_node_status[y] == -1:
+                app_log.debug(f"A: Node {y} is marked as failed in B")
+                _invalidate_successors(A, A_node_status, y)
+                continue
+
+            # Compare edges
+            if not edge_cmp(A, B, current_node, y):
+                app_log.debug(f"Edges between {current_node} and {y} differ")
+                _invalidate_successors(A, A_node_status, y)
+                _invalidate_successors(B, B_node_status, y)
+                continue
+
+            # Compare nodes
+            if not node_cmp(A, B, y):
+                app_log.debug(f"Attributes of node {y} differ:")
+                app_log.debug(f"A[y] = {A.nodes[y]}")
+                app_log.debug(f"B[y] = {B.nodes[y]}")
+                _invalidate_successors(A, A_node_status, y)
+                _invalidate_successors(B, B_node_status, y)
+                continue
+
+            # Predecessors subgraphs of y are the same in A and B, so
+            # enqueue y if it hasn't already been visited
+            assert A_node_status[y] != -1
+            if A_node_status[y] == 0:
+                A_node_status[y] = 1
+                B_node_status[y] = 1
+                app_log.debug(f"Enqueueing node {y}")
+                nodes_to_visit.appendleft(y)
+
+        # Prune children of current_node in B that aren't valid children in A
+        for y in B.adj[current_node]:
+            if B_node_status[y] == -1:
+                continue
+            if y not in A.adj[current_node]:
+                app_log.debug(f"B: {y} not adjacent to node {current_node} in A")
+                _invalidate_successors(B, B_node_status, y)
+                continue
+            if y in A.adj[current_node] and B_node_status[y] == -1:
+                app_log.debug(f"B: Node {y} is marked as failed in A")
+                _invalidate_successors(B, B_node_status, y)
+
+    A.remove_node(-1)
+    B.remove_node(-1)
+
+    app_log.debug("A node status:", A_node_status)
+    app_log.debug("B node status:", B_node_status)
+
+    for k, v in A_node_status.items():
+        A_node_status[k] = _status_map[v]
+    for k, v in B_node_status.items():
+        B_node_status[k] = _status_map[v]
+    return A_node_status, B_node_status

--- a/covalent/_workflow/transport.py
+++ b/covalent/_workflow/transport.py
@@ -277,14 +277,21 @@ def encode_metadata(metadata: dict) -> dict:
 
 
 # Default node comparison function for diffing transport graphs
-def _cmp_fstr_and_pval(A: nx.MultiDiGraph, B: nx.MultiDiGraph, node: int):
+def _cmp_fstr_meta_pval(A: nx.MultiDiGraph, B: nx.MultiDiGraph, node: int):
 
-    # Compare pickled functions and parameter values
+    # Compare metadata, pickled functions, and parameter values
 
     A_fn = A.nodes[node].get("function", None)
     B_fn = B.nodes[node].get("function", None)
     A_fn_str = A.nodes[node].get("function_string", "")
     B_fn_str = A.nodes[node].get("function_string", "")
+
+    A_meta = encode_metadata(A.nodes[node].get("metadata"))
+    B_meta = encode_metadata(B.nodes[node].get("metadata"))
+
+    # Compare metadata
+    if A_meta != B_meta:
+        return False
 
     # Compare function strings
     if A_fn_str != B_fn_str:
@@ -486,7 +493,7 @@ class _TransportGraph:
 
         return self._graph.copy()
 
-    def compare(self, other: "_TransportGraph", node_cmp=_cmp_fstr_and_pval) -> list:
+    def compare(self, other: "_TransportGraph", node_cmp=_cmp_fstr_meta_pval) -> list:
         """Returns a list of reusable nodes from another transport graph.
 
         Args:

--- a/tests/covalent_tests/workflow/transport_test.py
+++ b/tests/covalent_tests/workflow/transport_test.py
@@ -28,7 +28,12 @@ import pytest
 
 import covalent as ct
 from covalent._shared_files.defaults import parameter_prefix
-from covalent._workflow.transport import TransportableObject, _TransportGraph, encode_metadata
+from covalent._workflow.transport import (
+    TransportableObject,
+    _TransportGraph,
+    encode_metadata,
+    max_cbms,
+)
 
 
 def subtask(x):
@@ -457,3 +462,139 @@ def test_metadata_json_serialization():
 
     new_bash_dep = ct.DepsBash().from_dict(new_metadata["deps"]["bash"])
     assert new_bash_dep.__dict__ == metadata["deps"]["bash"].__dict__
+
+
+def test_max_cbms():
+    """Test function for determining a largest cbms"""
+
+    A = nx.MultiDiGraph()
+    B = nx.MultiDiGraph()
+    C = nx.MultiDiGraph()
+    D = nx.MultiDiGraph()
+
+    #    0     5  6
+    #  /  \
+    # 1    2
+    A.add_edge(0, 1)
+    A.add_edge(0, 2)
+    A.nodes[1]["color"] = "red"
+    A.add_node(5)
+    A.add_node(6)
+
+    #    0     5
+    #  /  \\
+    # 1    2
+    B.add_edge(0, 1)
+    B.add_edge(0, 2)
+    B.add_edge(0, 2)
+    B.nodes[1]["color"] = "black"
+    B.add_node(5)
+
+    #    0    3
+    #  /  \  /
+    # 1    2
+    C.add_edge(0, 1)
+    C.add_edge(0, 2)
+    C.add_edge(3, 2)
+
+    #    0    3
+    #  /  \  /
+    # 1    2
+    #     /
+    #   4
+    D.add_edge(0, 1)
+    D.add_edge(0, 2)
+    D.add_edge(3, 2)
+    D.add_edge(2, 4)
+
+    A_node_status, B_node_status = max_cbms(A, B)
+    assert A_node_status == {0: True, 1: False, 2: False, 5: True, 6: False}
+    assert B_node_status == {0: True, 1: False, 2: False, 5: True}
+
+    A_node_status, C_node_status = max_cbms(A, C)
+    assert A_node_status == {0: True, 1: False, 2: False, 5: False, 6: False}
+    assert C_node_status == {0: True, 1: False, 2: False, 3: False}
+
+    C_node_status, D_node_status = max_cbms(C, D)
+    assert C_node_status == {0: True, 1: True, 2: True, 3: True}
+    assert D_node_status == {0: True, 1: True, 2: True, 3: True, 4: False}
+
+
+def test_transport_graph_compare():
+    """Test method for computing reusable nodes from another transport graph"""
+
+    @ct.electron
+    def task_1(x):
+        return x
+
+    @ct.electron
+    def task_2(x):
+        return 2 * x
+
+    @ct.electron
+    def task_2a(x, y):
+        return x + y
+
+    @ct.electron
+    def task_3(x):
+        return 3 * x
+
+    #  1 -> 0
+    @ct.lattice
+    def workflow_1(x):
+        res1 = task_1(x)
+        return res1
+
+    # 1 -> 0 -> 2
+    @ct.lattice
+    def workflow_2(x):
+        res1 = task_1(x)
+        res2 = task_2(res1)
+        return res2
+
+    # 1 -> 0 -> 2
+    @ct.lattice
+    def workflow_3(x):
+        res1 = task_1(x)
+        res2 = task_3(res1)
+        return res2
+
+    #      1  2   5
+    #     /    \ /
+    #    0      3
+    #  /
+    # 4
+    @ct.lattice
+    def workflow_4(x, y, z):
+        res1 = task_1(x)
+        res2 = task_1(y)
+        res3 = task_2(res1)
+        res4 = task_2a(res2, z)
+
+    return 1
+
+    workflow_1.build_graph(5)
+    workflow_2.build_graph(5)
+    workflow_3.build_graph(5)
+
+    tg1 = workflow_1.transport_graph
+    tg2 = workflow_2.transport_graph
+    tg3 = workflow_3.transport_graph
+
+    assert tg1.compare(tg2) == [0, 1]
+    assert tg2.compare(tg2) == [0, 1, 2]
+    assert tg2.compare(tg3) == [0, 1]
+
+    workflow_3.build_graph(2)
+    tg3 = workflow_3.transport_graph
+    assert tg2.compare(tg3) == []
+
+    workflow_4.build_graph(1, 2, 3)
+    tg4_1 = workflow_4.transport_graph
+    workflow_4.build_graph(1, 2, 4)
+    tg4_2 = workflow_4.transport_graph
+    workflow_4.build_Graph(1, 3, 3)
+    tg4_3 = workflow_4.transport_graph
+
+    assert tg4_1.compare(tg4_2) == [0, 1, 2, 4]
+    assert tg4_1.compare(tg4_3) == [0, 1, 4]


### PR DESCRIPTION
Add methods for determining which portion of an existing transport
graph can be reused in another transport graph.

The core function `max_cbms()` computes a common subgraph C of two
rooted DAGs A and B with the following properties:

* C is "backward-maximal" in the sense that all paths from the root
that terminate in C are contained in C.
* C is the largest such subgraph

If A and B represent computational graphs, C describes the tasks in A
and B with the same dependencies.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Increment the version number in the /VERSION file. If this is a bugfix, increment the patch version (the rightmost number), for example 0.18.2 becomes 0.18.3. If it's a new feature, increment the minor version (the middle number), for example 0.18.2 becomes 0.19.0. 
⚠️ Add a note to /CHANGELOG.md with your version number and the date, summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Rebase the latest changes from the develop branch. Assuming origin points to https://github.com/AgnostiqHQ/covalent, you should run git rebase origin/develop.
-->

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.

Closes #920 