### PR TITLE
Make `BaseAsyncExecutor` a sibling of `BaseExecutor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Make `BaseExecutor` and `BaseAsyncExecutor` class siblings, not parent and child.
+
 ### Tests
 
 - Fixed randomly failing lattice json serialization test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles==0.8.0
 alembic==1.8.0
 cloudpickle==2.0.0
 dask[distributed]==2022.6.0

--- a/tests/covalent_tests/executor/base_test.py
+++ b/tests/covalent_tests/executor/base_test.py
@@ -28,7 +28,7 @@ from functools import partial
 
 from covalent import DepsCall, TransportableObject
 from covalent.executor import BaseExecutor, wrapper_fn
-from covalent.executor.base import BaseAsyncExecutor
+from covalent.executor.base import BaseAsyncExecutor, _AbstractBaseExecutor
 
 
 class MockExecutor(BaseExecutor):
@@ -331,3 +331,47 @@ def test_base_async_executor_passes_task_metadata(mocker):
     metadata, stdout, stderr = asyncio.run(awaitable)
     task_metadata = {"dispatch_id": dispatch_id, "node_id": node_id, "results_dir": results_dir}
     assert metadata == task_metadata
+
+
+def test_async_write_streams_to_file(mocker):
+    """Test write log streams to file method in BaseAsyncExecutor via LocalExecutor."""
+
+    import asyncio
+
+    me = MockAsyncExecutor()
+
+    # Case 1 - Check that relative log files that are written to are constructed in the results directory that is explicitly passed as an argument.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_file = "relative.log"
+        write_awaitable = me.write_streams_to_file(
+            stream_strings=["relative"], filepaths=[tmp_file], dispatch_id="", results_dir=tmp_dir
+        )
+        asyncio.run(write_awaitable)
+        assert "relative.log" in os.listdir(tmp_dir)
+
+        with open(f"{tmp_dir}/relative.log") as f:
+            lines = f.readlines()
+        assert lines[0] == "relative"
+
+    # Case 2 - Check that absolute log files that are written to are constructed in the results directory that is explicitly passed as an argument.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_file = tempfile.NamedTemporaryFile()
+        write_awaitable = me.write_streams_to_file(
+            stream_strings=["absolute"],
+            filepaths=[tmp_file.name],
+            dispatch_id="",
+            results_dir=tmp_dir,
+        )
+        asyncio.run(write_awaitable)
+
+        assert os.path.isfile(tmp_file.name)
+
+        with open(tmp_file.name) as f:
+            lines = f.readlines()
+        assert lines[0] == "absolute"
+
+
+def test_abstract_base_executor_init():
+    be = _AbstractBaseExecutor(log_stdout="/tmp/stdout.log", log_stderr="/tmp/stderr.log")
+    assert be.log_stdout == "/tmp/stdout.log"
+    assert be.log_stderr == "/tmp/stderr.log"


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Increment the version number in the /VERSION file. If this is a bugfix, increment the patch version (the rightmost number), for example 0.18.2 becomes 0.18.3. If it's a new feature, increment the minor version (the middle number), for example 0.18.2 becomes 0.19.0. 
⚠️ Add a note to /CHANGELOG.md with your version number and the date, summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Rebase the latest changes from the develop branch. Assuming origin points to https://github.com/AgnostiqHQ/covalent, you should run git rebase origin/develop.
-->

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.

This also introduces a private `_AbstractBaseExecutor` class
containing a few common attributes and methods.

`BaseAsyncExecutor` is logically related to but not derived from
`BaseExecutor` because the core methods are invoked
differently.

By not deriving `BaseAsyncExecutor` from `BaseExecutor`,
we also prevent mistakes like the following:

Let `executor` be derived from `BaseAsyncExecutor`.

```python
if isinstance(executor, BaseExecutor):
    # BaseAsyncExecutors are BaseExecutors. But this doesn't work b/c
    # execute() is a coroutine, not an ordinary function.
    executor.execute()
else:
    await executor.execute()
```
Closes #978 

