### PR TITLE
Make `BaseAsyncExecutor` and `BaseExecutor` siblings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Check out SHA
         if: >
-          github.event_name == 'workflow_dispatch' 
+          github.event_name == 'workflow_dispatch'
           && github.event.inputs.commit_sha
         uses: actions/checkout@v3
         with:
@@ -103,7 +103,7 @@ jobs:
             - '.github/workflows/*.yml'
             tests:
             - 'tests/**'
-            
+
       - name: Set up Python
         if: >
           matrix.os == 'macos-latest'
@@ -202,6 +202,16 @@ jobs:
           diff -x .gitignore -r covalent-${VERSION}/covalent_dispatcher ../covalent_dispatcher
           diff -x README.md -r covalent-${VERSION}/covalent_migrations ../covalent_migrations
           diff -x .gitignore -x README.md -x webapp covalent-${VERSION}/covalent_ui ../covalent_ui
+          rm -rf covalent-${VERSION}/
+
+      - name: Validate webapp
+        if: >
+          github.event_name != 'pull_request'
+          || steps.working-directory.outputs.ui_frontend == 'true'
+        run: |
+          VERSION="$(cat ./VERSION)"
+          cd dist
+          tar xzf covalent-${VERSION}.tar.gz
           diff -r covalent-${VERSION}/covalent_ui/webapp/build ../covalent_ui/webapp/build
           rm -rf covalent-${VERSION}/
 
@@ -222,13 +232,13 @@ jobs:
           || steps.working-directory.outputs.actions == 'true'
           || steps.working-directory.outputs.tests == 'true'
         run: covalent start --ignore-migrations
-               
+
       - name: Run SDK tests and measure coverage
         if: >
           github.event_name != 'pull_request'
           || steps.working-directory.outputs.sdk == 'true'
         run: PYTHONPATH=$PWD/ pytest -vv --reruns=5 tests/covalent_tests --cov=covalent --cov-config=.coveragerc
-            
+
       - name: Generate SDK coverage report
         if: >
           github.event_name != 'pull_request'
@@ -240,7 +250,7 @@ jobs:
           github.event_name != 'pull_request'
           || steps.working-directory.outputs.dispatcher == 'true'
         run: PYTHONPATH=$PWD/ pytest -vv --reruns=5 tests/covalent_dispatcher_tests --cov=covalent_dispatcher --cov-config=.coveragerc
-      
+
       - name: Generate dispatcher coverage report
         if: >
           github.event_name != 'pull_request'
@@ -253,7 +263,7 @@ jobs:
           || steps.working-directory.outputs.actions == 'true'
           || steps.working-directory.outputs.tests == 'true'
         run: PYTHONPATH=$PWD/ pytest -vv --reruns=5 tests/functional_tests  --cov=covalent --cov=covalent_dispatcher --cov-config=.coveragerc
-      
+
       - name: Generate functional test coverage report
         if: >
           github.event_name != 'pull_request'
@@ -268,10 +278,10 @@ jobs:
           && (github.event_name != 'pull_request'
           || steps.working-directory.outputs.ui_backend == 'true')
         run: PYTHONPATH=$PWD/ pytest -vv --reruns=5 tests/covalent_ui_tests --cov=covalent_ui --cov-config=.coveragerc
-      
+
       - name: Generate UI backend coverage report
         continue-on-error: true
-        if: > 
+        if: >
           false
           && (github.event_name != 'pull_request'
           || (steps.working-directory.outputs.ui_backend_tests == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make `BaseExecutor` and `BaseAsyncExecutor` class siblings, not parent and child.
 
+### Operations
+
+- Only validate webapp if the webapp was built
+
 ### Tests
 
 - Fixed randomly failing lattice json serialization test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Make `BaseExecutor` and `BaseAsyncExecutor` class siblings, not parent and child.
+
 ### Tests
 
 - Fixed randomly failing lattice json serialization test

--- a/covalent/executor/base.py
+++ b/covalent/executor/base.py
@@ -110,14 +110,6 @@ class _AbstractBaseExecutor(ABC):
     BaseExecutor and BaseAsyncExecutor
     """
 
-    def __init__(
-        self,
-        log_stdout: str = "",
-        log_stderr: str = "",
-    ) -> None:
-        self.log_stdout = log_stdout
-        self.log_stderr = log_stderr
-
     def get_dispatch_context(self, dispatch_info: DispatchInfo) -> ContextManager[DispatchInfo]:
         """
         Start a context manager that will be used to
@@ -186,9 +178,12 @@ class BaseExecutor(_AbstractBaseExecutor):
         conda_env: str = "",
         cache_dir: str = "",
         current_env_on_conda_fail: bool = False,
+        *args,
+        **kwargs,
     ) -> None:
 
-        super().__init__(log_stdout, log_stderr)
+        self.log_stdout = log_stdout
+        self.log_stderr = log_stderr
         self.conda_env = conda_env
         self.cache_dir = cache_dir
         self.current_env_on_conda_fail = current_env_on_conda_fail
@@ -505,12 +500,12 @@ class BaseAsyncExecutor(_AbstractBaseExecutor):
         self,
         log_stdout: str = "",
         log_stderr: str = "",
-        conda_env: str = "",
-        cache_dir: str = "",
-        current_env_on_conda_fail: bool = False,
+        *args,
+        **kwargs,
     ) -> None:
 
-        super().__init__(log_stdout, log_stderr)
+        self.log_stdout = log_stdout
+        self.log_stderr = log_stderr
 
     async def write_streams_to_file(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles==0.8.0
 alembic==1.8.0
 cloudpickle==2.0.0
 dask[distributed]==2022.6.0

--- a/tests/covalent_tests/executor/base_test.py
+++ b/tests/covalent_tests/executor/base_test.py
@@ -28,7 +28,7 @@ from functools import partial
 
 from covalent import DepsCall, TransportableObject
 from covalent.executor import BaseExecutor, wrapper_fn
-from covalent.executor.base import BaseAsyncExecutor
+from covalent.executor.base import BaseAsyncExecutor, _AbstractBaseExecutor
 
 
 class MockExecutor(BaseExecutor):
@@ -331,3 +331,47 @@ def test_base_async_executor_passes_task_metadata(mocker):
     metadata, stdout, stderr = asyncio.run(awaitable)
     task_metadata = {"dispatch_id": dispatch_id, "node_id": node_id, "results_dir": results_dir}
     assert metadata == task_metadata
+
+
+def test_async_write_streams_to_file(mocker):
+    """Test write log streams to file method in BaseAsyncExecutor via LocalExecutor."""
+
+    import asyncio
+
+    me = MockAsyncExecutor()
+
+    # Case 1 - Check that relative log files that are written to are constructed in the results directory that is explicitly passed as an argument.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_file = "relative.log"
+        write_awaitable = me.write_streams_to_file(
+            stream_strings=["relative"], filepaths=[tmp_file], dispatch_id="", results_dir=tmp_dir
+        )
+        asyncio.run(write_awaitable)
+        assert "relative.log" in os.listdir(tmp_dir)
+
+        with open(f"{tmp_dir}/relative.log") as f:
+            lines = f.readlines()
+        assert lines[0] == "relative"
+
+    # Case 2 - Check that absolute log files that are written to are constructed in the results directory that is explicitly passed as an argument.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_file = tempfile.NamedTemporaryFile()
+        write_awaitable = me.write_streams_to_file(
+            stream_strings=["absolute"],
+            filepaths=[tmp_file.name],
+            dispatch_id="",
+            results_dir=tmp_dir,
+        )
+        asyncio.run(write_awaitable)
+
+        assert os.path.isfile(tmp_file.name)
+
+        with open(tmp_file.name) as f:
+            lines = f.readlines()
+        assert lines[0] == "absolute"
+
+
+def test_abstract_base_executor_init():
+    be = _AbstractBaseExecutor(log_stdout="/tmp/stdout.log", log_stderr="/tmp/stderr.log")
+    assert be.log_stdout == "/tmp/stdout.log"
+    assert be.log_stderr == "/tmp/stderr.log"

--- a/tests/covalent_tests/executor/base_test.py
+++ b/tests/covalent_tests/executor/base_test.py
@@ -369,9 +369,3 @@ def test_async_write_streams_to_file(mocker):
         with open(tmp_file.name) as f:
             lines = f.readlines()
         assert lines[0] == "absolute"
-
-
-def test_abstract_base_executor_init():
-    be = _AbstractBaseExecutor(log_stdout="/tmp/stdout.log", log_stderr="/tmp/stderr.log")
-    assert be.log_stdout == "/tmp/stdout.log"
-    assert be.log_stderr == "/tmp/stderr.log"

--- a/tests/covalent_tests/workflow/lattice_serialization_test.py
+++ b/tests/covalent_tests/workflow/lattice_serialization_test.py
@@ -35,7 +35,7 @@ def test_lattice_json_serialization():
         return f(x)
 
     workflow.build_graph(5)
-    workflow.cova_imports = set("dummy_module")
+    workflow.cova_imports = set({"dummy_module"})
 
     json_workflow = workflow.serialize_to_json()
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Increment the version number in the /VERSION file. If this is a bugfix, increment the patch version (the rightmost number), for example 0.18.2 becomes 0.18.3. If it's a new feature, increment the minor version (the middle number), for example 0.18.2 becomes 0.19.0. 
⚠️ Add a note to /CHANGELOG.md with your version number and the date, summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Rebase the latest changes from the develop branch. Assuming origin points to https://github.com/AgnostiqHQ/covalent, you should run git rebase origin/develop.
-->

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.

This also introduces a private `_AbstractBaseExecutor` class
containing a few common attributes and methods.

`BaseAsyncExecutor` is logically related to but not derived from
`BaseExecutor` because the core `execute()` methods are invoked
differently.

By not deriving `BaseAsyncExecutor` from `BaseExecutor`, we also
prevent mistakes like the following:

Let `executor` be derived from `BaseAsyncExecutor`.

```python
if isinstance(executor, BaseExecutor):
    # BaseAsyncExecutors are BaseExecutors. But this doesn't work b/c
    # execute() is a coroutine.
    executor.execute()
else:
    await executor.execute()
```

Closes #978

Also addresses the following CI issues: 
Closes #980 (second attempt), 
Closes #984.
