### PR TITLE
Delay returning from covalent start until the endpoints are live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Exceptions when instantiating executors are handled
+- Covalent start now waits for the server to settle before returning
 
 ## [0.202.0] - 2022-10-11
 

--- a/covalent_dispatcher/_cli/service.py
+++ b/covalent_dispatcher/_cli/service.py
@@ -27,12 +27,14 @@ import json
 import os
 import shutil
 import socket
+import time
 from subprocess import DEVNULL, Popen
 from typing import Optional
 
 import click
 import dask.system
 import psutil
+import requests
 from distributed.comm import unparse_address
 from distributed.core import connect, rpc
 
@@ -189,6 +191,16 @@ def _graceful_start(
     with open(pidfile, "w") as PIDFILE:
         PIDFILE.write(str(pid))
 
+    # Wait until the server actually starts listening on the port
+    dispatcher_addr = f"http://localhost:{port}"
+    up = False
+    while not up:
+        try:
+            requests.get(dispatcher_addr, timeout=1)
+            up = True
+        except requests.exceptions.ConnectionError as err:
+            time.sleep(1)
+
     click.echo(f"Covalent server has started at http://localhost:{port}")
     return port
 
@@ -328,16 +340,6 @@ def start(
     port = _graceful_start(UI_SRVDIR, UI_PIDFILE, UI_LOGFILE, port, no_cluster, develop)
     set_config("user_interface.port", port)
     set_config("dispatcher.port", port)
-
-    # Wait until the server actually starts listening on the port
-    server_listening = False
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    while not server_listening:
-        try:
-            sock.bind(("localhost", port))
-            sock.close()
-        except OSError:
-            server_listening = True
 
 
 @click.command()

--- a/tests/covalent_dispatcher_tests/_cli/service_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/service_test.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, Mock
 
 import mock
 import pytest
+import requests
 from click.testing import CliRunner
 
 from covalent_dispatcher._cli.service import (
@@ -158,6 +159,35 @@ def test_graceful_start_when_pid_absent(mocker):
     popen_mock.assert_called_once()
     click_echo_mock.assert_called_once()
     read_pid_mock.assert_called_once()
+
+
+def test_graceful_start_waits_to_return(mocker):
+    """Check that graceful server start function doesn't return until
+    the endpoints are live."""
+
+    read_pid_mock = mocker.patch("covalent_dispatcher._cli.service._read_pid")
+    pid_exists_mock = mocker.patch("psutil.pid_exists", return_value=False)
+    rm_pid_file_mock = mocker.patch("covalent_dispatcher._cli.service._rm_pid_file")
+    next_available_port_mock = mocker.patch(
+        "covalent_dispatcher._cli.service._next_available_port", return_value=1984
+    )
+    popen_mock = mocker.patch("covalent_dispatcher._cli.service.Popen")
+    click_echo_mock = mocker.patch("click.echo")
+    requests_mock = mocker.patch(
+        "covalent_dispatcher._cli.service.requests.get",
+        side_effect=requests.exceptions.ConnectionError(),
+    )
+    sleep_mock = mocker.patch(
+        "covalent_dispatcher._cli.service.time.sleep", side_effect=RuntimeError()
+    )
+
+    with mock.patch("covalent_dispatcher._cli.service.open", mock.mock_open()):
+        with pytest.raises(RuntimeError):
+            res = _graceful_start("", "", "output.log", 15, False)
+
+        pass
+
+    sleep_mock.assert_called_once()
 
 
 def test_graceful_shutdown_running_server(mocker):

--- a/tests/covalent_dispatcher_tests/_cli/service_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/service_test.py
@@ -144,6 +144,9 @@ def test_graceful_start_when_pid_absent(mocker):
     )
     popen_mock = mocker.patch("covalent_dispatcher._cli.service.Popen")
     click_echo_mock = mocker.patch("click.echo")
+    requests_mock = mocker.patch(
+        "covalent_dispatcher._cli.service.requests.get",
+    )
 
     with mock.patch("covalent_dispatcher._cli.service.open", mock.mock_open()):
         res = _graceful_start("", "", "output.log", 15, False)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Increment the version number in the /VERSION file. If this is a bugfix, increment the patch version (the rightmost number), for example 0.18.2 becomes 0.18.3. If it's a new feature, increment the minor version (the middle number), for example 0.18.2 becomes 0.19.0.
⚠️ Add a note to /CHANGELOG.md with your version number and the date, summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Rebase the latest changes from the develop branch. Assuming origin points to https://github.com/AgnostiqHQ/covalent, you should run git rebase origin/develop.
-->

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.

Confirm that the endpoints are live before returning from `covalent start`.