### PR TITLE
Fixed missing RTD content under API section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Docs
+
+- Fixed missing RTD content under API section for covalent, cli, leptons, deps, data transfer
+
 ### Fixed
 
 - Enabling logging by default

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,10 +1,4 @@
 autodocsumm==0.2.6
-covalent-awsbatch-plugin==0.9.0rc0
-covalent-awslambda-plugin==0.3.2rc0
-covalent-braket-plugin==0.3.0rc0
-covalent-ecs-plugin==0.7.0rc0
-covalent-slurm-plugin
-covalent-ssh-plugin
 docutils
 furo>=2022.6.21
 ipython>=8.4.0


### PR DESCRIPTION
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.

There seems to be a version conflict when attempting to include the individual executor plugins in the docs requirements (docs pipeline has covalent at a certain version and aws plugins is pinned to 0.177.0 post dev) which is causing large portions of RTD particularly the API section to have missing content. Solution for now is to remove the executors from docs dependencies which shouldn't cause much of a difference in the RTDs as the docs for executors are quite refined without having to include the interface for the executor classes themselves.

Long term solution includes making sure semver versioning ranges for aws plugins module allows for some flexibility. 