### PR TITLE
Running migrations automatically if none have run in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Running migrations automatically if none have run in the past (fresh installs, after purging)
+
 ## [0.206.0-rc.0] - 2022-10-26
 
 ### Authors

--- a/covalent_dispatcher/_cli/service.py
+++ b/covalent_dispatcher/_cli/service.py
@@ -319,6 +319,11 @@ def start(
         set_config({"sdk.log_level": "debug"})
 
     db = DataStore.factory()
+
+    # No migrations have run as of yet - run them automatically
+    if db.current_revision() == None:
+        db.run_migrations(logging_enabled=False)
+
     if db.is_migration_pending and not ignore_migrations:
         click.secho(MIGRATION_WARNING_MSG, fg="yellow")
         click.echo(MIGRATION_COMMAND_MSG)

--- a/covalent_dispatcher/_cli/service.py
+++ b/covalent_dispatcher/_cli/service.py
@@ -321,7 +321,7 @@ def start(
     db = DataStore.factory()
 
     # No migrations have run as of yet - run them automatically
-    if db.current_revision() == None:
+    if not ignore_migrations and db.current_revision() == None:
         db.run_migrations(logging_enabled=False)
 
     if db.is_migration_pending and not ignore_migrations:

--- a/covalent_dispatcher/_cli/service.py
+++ b/covalent_dispatcher/_cli/service.py
@@ -329,6 +329,12 @@ def start(
         click.echo(MIGRATION_COMMAND_MSG)
         return ctx.exit(1)
 
+    if ignore_migrations and db.is_migration_pending:
+        click.secho(
+            'Warning: Ignoring migrations is not recommended and may have unanticipated side effects. Use "covalent db migrate" to run migrations.',
+            fg="yellow",
+        )
+
     set_config("user_interface.port", port)
     set_config("dispatcher.port", port)
 

--- a/covalent_dispatcher/_cli/service.py
+++ b/covalent_dispatcher/_cli/service.py
@@ -321,7 +321,7 @@ def start(
     db = DataStore.factory()
 
     # No migrations have run as of yet - run them automatically
-    if not ignore_migrations and db.current_revision() is not None:
+    if not ignore_migrations and db.current_revision() is None:
         db.run_migrations(logging_enabled=False)
 
     if db.is_migration_pending and not ignore_migrations:

--- a/covalent_dispatcher/_cli/service.py
+++ b/covalent_dispatcher/_cli/service.py
@@ -321,7 +321,7 @@ def start(
     db = DataStore.factory()
 
     # No migrations have run as of yet - run them automatically
-    if not ignore_migrations and db.current_revision() == None:
+    if not ignore_migrations and db.current_revision() is not None:
         db.run_migrations(logging_enabled=False)
 
     if db.is_migration_pending and not ignore_migrations:

--- a/covalent_dispatcher/_db/dispatchdb.py
+++ b/covalent_dispatcher/_db/dispatchdb.py
@@ -31,8 +31,6 @@ from covalent._shared_files import logger
 from covalent._shared_files.config import get_config
 from covalent._shared_files.util_classes import Status
 
-from .datastore import DataStore
-
 app_log = logger.app_log
 log_stack_info = logger.log_stack_info
 # DB Schema:
@@ -177,8 +175,3 @@ class DispatchDB:
 
     def __exit__(self, exc_type, exc_value, traceback):
         return False
-
-    def _get_data_store(self, initialize_db: bool = False) -> DataStore:
-        """Return the DataStore instance to write records."""
-
-        return DataStore(db_URL=f"sqlite+pysqlite:///{self._dbpath}", initialize_db=initialize_db)

--- a/covalent_ui/app.py
+++ b/covalent_ui/app.py
@@ -28,7 +28,6 @@ from fastapi.templating import Jinja2Templates
 
 from covalent._shared_files import logger
 from covalent._shared_files.config import get_config
-from covalent_dispatcher._db.datastore import DataStore
 from covalent_dispatcher._service.app_dask import DaskCluster
 from covalent_ui.api.main import app as fastapi_app
 from covalent_ui.api.main import sio
@@ -101,9 +100,6 @@ if __name__ == "__main__":
     if args.cluster:
         dask_cluster = DaskCluster(name="LocalDaskCluster", logger=app_log)
         dask_cluster.start()
-
-    # Initialize the database
-    DataStore(initialize_db=True)
 
     # Start covalent main app
     uvicorn.run(

--- a/tests/covalent_dispatcher_tests/_cli/service_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/service_test.py
@@ -257,8 +257,8 @@ def test_start(mocker, monkeypatch, is_migration_pending, ignore_migrations, cur
 
     res = runner.invoke(start, cli_args)
 
-    # if current_revision is None no migrations have been run 
-    if current_revision is None and not ignore_migrations: 
+    # if current_revision is None no migrations have been run
+    if current_revision is None and not ignore_migrations:
         db_mock.current_revision.assert_called_once()
 
     if ignore_migrations or not is_migration_pending:

--- a/tests/covalent_dispatcher_tests/_cli/service_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/service_test.py
@@ -226,8 +226,14 @@ def test_graceful_shutdown_stopped_server(mocker):
 @pytest.mark.parametrize(
     "is_migration_pending, ignore_migrations, current_revision",
     [
-        (True, True, None), (True, False, None), (False, False, None), (False, True, None),
-        (True, True, "112233"), (True, False, "112233"), (False, False, "112233"), (False, True, "112233")
+        (True, True, None),
+        (True, False, None),
+        (False, False, None),
+        (False, True, None),
+        (True, True, "112233"),
+        (True, False, "112233"),
+        (False, False, "112233"),
+        (False, True, "112233"),
     ],
 )
 def test_start(mocker, monkeypatch, is_migration_pending, ignore_migrations, current_revision):

--- a/tests/covalent_dispatcher_tests/_cli/service_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/service_test.py
@@ -224,10 +224,13 @@ def test_graceful_shutdown_stopped_server(mocker):
 
 
 @pytest.mark.parametrize(
-    "is_migration_pending, ignore_migrations",
-    [(True, True), (True, False), (False, False), (False, True)],
+    "is_migration_pending, ignore_migrations, current_revision",
+    [
+        (True, True, None), (True, False, None), (False, False, None), (False, True, None),
+        (True, True, "112233"), (True, False, "112233"), (False, False, "112233"), (False, True, "112233")
+    ],
 )
-def test_start(mocker, monkeypatch, is_migration_pending, ignore_migrations):
+def test_start(mocker, monkeypatch, is_migration_pending, ignore_migrations, current_revision):
     """Test the start CLI command."""
 
     runner = CliRunner()
@@ -245,6 +248,7 @@ def test_start(mocker, monkeypatch, is_migration_pending, ignore_migrations):
     monkeypatch.setattr("covalent_dispatcher._cli.service.UI_LOGFILE", "mock")
 
     db_mock.is_migration_pending = is_migration_pending
+    db_mock.current_revision.return_value = current_revision
 
     cli_args = f"--port {port_val} -d"
 
@@ -253,10 +257,13 @@ def test_start(mocker, monkeypatch, is_migration_pending, ignore_migrations):
 
     res = runner.invoke(start, cli_args)
 
+    # if current_revision is None no migrations have been run 
+    if current_revision is None and not ignore_migrations: 
+        db_mock.current_revision.assert_called_once()
+
     if ignore_migrations or not is_migration_pending:
         graceful_start_mock.assert_called_once()
         assert set_config_mock.call_count == 6
-        # set_config_mock.assert_called_once()
     else:
         assert MIGRATION_COMMAND_MSG in res.output
         assert MIGRATION_WARNING_MSG in res.output

--- a/tests/covalent_dispatcher_tests/_service/app_test.py
+++ b/tests/covalent_dispatcher_tests/_service/app_test.py
@@ -147,7 +147,6 @@ def test_get_result_503(mocker, app, client, test_db_file, tmp_path):
 
 def test_get_result_dispatch_id_not_found(mocker, test_db_file, client, tmp_path):
 
-    mocker.patch.object(DispatchDB, "_get_data_store", test_db_file)
     mocker.patch("covalent_dispatcher._service.app._result_from", return_value={})
     mocker.patch("covalent_dispatcher._service.app.workflow_db", test_db_file)
     mocker.patch("covalent_dispatcher._service.app.Lattice", MockLattice)


### PR DESCRIPTION
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
