### PR TITLE
Fix s3 folder download bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Folder transfer download bug
 - Result objects now print correctly when nodes fail
 
 ## [0.207.0-rc.0] - 2022-10-26

--- a/covalent/_file_transfer/strategies/s3_strategy.py
+++ b/covalent/_file_transfer/strategies/s3_strategy.py
@@ -95,15 +95,22 @@ class S3(FileTransferStrategy):
                     "s3",
                     region_name=self.region_name,
                 )
+
                 for obj_metadata in s3.list_objects(Bucket=bucket_name, Prefix=from_filepath)[
                     "Contents"
                 ]:
                     obj_key = obj_metadata["Key"]
                     obj_destination_filepath = Path(to_filepath) / obj_key
-                    if obj_key.endswith("/"):
-                        obj_destination_filepath.mkdir(parents=True, exist_ok=True)
-                    else:
-                        s3.download_file(bucket_name, obj_key, str(obj_destination_filepath))
+                    if not obj_key.endswith("/"):
+                        obj_destination_filepath.parents[0].mkdir(parents=True, exist_ok=True)
+                        app_log.debug(
+                            f"Downloading file {str(Path(from_filepath) / obj_key)} to {str(obj_destination_filepath)}."
+                        )
+                        s3.download_file(
+                            bucket_name,
+                            str(Path(from_filepath) / obj_key),
+                            str(obj_destination_filepath),
+                        )
 
         else:
 


### PR DESCRIPTION
Boto3 `list_objects` is unreliable when it comes to listing the directories. When directories are created on the console, they are listed, while directories uploaded using boto3 were not returned by `list_objects`. This PR uses pathlib package to reliably create the subdirectory packages that are needed when downloading files from s3.

Also reported this as a probable [bug report](https://github.com/boto/boto3/issues/3340) to boto3.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Increment the version number in the /VERSION file. If this is a bugfix, increment the patch version (the rightmost number), for example 0.18.2 becomes 0.18.3. If it's a new feature, increment the minor version (the middle number), for example 0.18.2 becomes 0.19.0.
⚠️ Add a note to /CHANGELOG.md with your version number and the date, summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Rebase the latest changes from the develop branch. Assuming origin points to https://github.com/AgnostiqHQ/covalent, you should run git rebase origin/develop.
-->

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
