### PR TITLE
mock set_config so as to not set port as 42 in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Helpful message when trying to dispatch a workflow when covalent server is not available
 - Open UI preview of transport graph when `lattice.draw()` is invoked and print URL of the same
 - Defer creation of server specific config entries until covalent is started
+- Functional tests on CI
 
 ### Docs
 

--- a/tests/covalent_dispatcher_tests/_cli/service_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/service_test.py
@@ -1017,6 +1017,7 @@ def test_sdk_no_cluster(mocker, monkeypatch):
     )
     db_mock = Mock()
     mocker.patch.object(DataStore, "factory", lambda: db_mock)
+    mocker.patch("covalent_dispatcher._cli.service.set_config")
     monkeypatch.setattr("covalent_dispatcher._cli.service.UI_SRVDIR", "mock")
     monkeypatch.setattr("covalent_dispatcher._cli.service.UI_PIDFILE", "mock")
     monkeypatch.setattr("covalent_dispatcher._cli.service.UI_LOGFILE", "mock")

--- a/tests/covalent_dispatcher_tests/_cli/service_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/service_test.py
@@ -1017,7 +1017,7 @@ def test_sdk_no_cluster(mocker, monkeypatch):
     )
     db_mock = Mock()
     mocker.patch.object(DataStore, "factory", lambda: db_mock)
-    mocker.patch("covalent_dispatcher._cli.service.set_config")
+    set_config_mock = mocker.patch("covalent_dispatcher._cli.service.set_config")
     monkeypatch.setattr("covalent_dispatcher._cli.service.UI_SRVDIR", "mock")
     monkeypatch.setattr("covalent_dispatcher._cli.service.UI_PIDFILE", "mock")
     monkeypatch.setattr("covalent_dispatcher._cli.service.UI_LOGFILE", "mock")
@@ -1028,6 +1028,7 @@ def test_sdk_no_cluster(mocker, monkeypatch):
 
     res = runner.invoke(start, cli_args)
 
+    assert set_config_mock.call_count == 6
     graceful_start_mock.assert_called_once()
 
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Increment the version number in the /VERSION file. If this is a bugfix, increment the patch version (the rightmost number), for example 0.18.2 becomes 0.18.3. If it's a new feature, increment the minor version (the middle number), for example 0.18.2 becomes 0.19.0.
⚠️ Add a note to /CHANGELOG.md with your version number and the date, summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Rebase the latest changes from the develop branch. Assuming origin points to https://github.com/AgnostiqHQ/covalent, you should run git rebase origin/develop.
-->

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.

This should hopefully help fix functional tests on CI...