### PR TITLE
Fix waiting order of electrons in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Redispatch feature page in Read the Docs.
 - Clarify installation instructions for SLURM plugin in Read the Docs (x2).
+- Fix waiting order of electrons in docs inside snippet for adding a dependency when inputs and outputs are independent.
 
 ### Fixed
 

--- a/doc/source/how_to/coding/wait_for_another_electron.ipynb
+++ b/doc/source/how_to/coding/wait_for_another_electron.ipynb
@@ -58,7 +58,7 @@
     "    arg_B = 0\n",
     "    result_B = task_B(arg_B)\n",
     "    result_A = task_A(arg_A)\n",
-    "    ct.wait(result_B, result_A) # Wait for result_A before computing result_B"
+    "    ct.wait(result_A, result_B) # Wait for result_B before computing result_A"
    ]
   },
   {


### PR DESCRIPTION
The document says for task A to wait on task B but the snippet was doing the opposite.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
