### PR TITLE
Add missing `,` to Slurm docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Docs
+- Added a missing `,` to the Slurm docs.
+
 ### Operations
 
 - Update the PR template.

--- a/doc/source/api/executors/slurm.rst
+++ b/doc/source/api/executors/slurm.rst
@@ -109,7 +109,7 @@ More complex jobs can be crafted by using these optional parameters. For example
            "cpu-bind": "cores",
            "G": 4,
            "gpu-bind": "single:1"
-       }
+       },
        srun_append="nsys profile --stats=true -t cuda --gpu-metrics-device=all",
        postrun_commands=[
            "srun --ntasks-per-node 1 dcgmi profile --resume",


### PR DESCRIPTION
Closes #1695. Also opened a PR in the plugin repo here: https://github.com/AgnostiqHQ/covalent-slurm-plugin/pull/72.

- [N/A] I have added the tests to cover my changes.
- [X] I have updated the documentation and CHANGELOG accordingly.
- [X] I have read the CONTRIBUTING document.
