### PR TITLE
Remove duplicate "stop server" warning in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added documentation for Azure Blob Storage file transfers
 - Added documentation for Google Cloud Storage file transfers
+- Removed duplicate "stop server" warning in the First Experimemnt page
 
 ### Changed
 

--- a/doc/source/getting_started/first_experiment/index.rst
+++ b/doc/source/getting_started/first_experiment/index.rst
@@ -217,8 +217,6 @@ Do the following to view your workflow in the GUI.
 
 While the workflow is being processed by the dispatch server, you can terminate the Jupyter kernel or Python console process without losing access to the results.
 
-.. warning:: Do not stop the Covalent server while you have running workflows. Stopping the server will kill the workflows.
-
 
 What to Do Next
 ###############


### PR DESCRIPTION
The warning "Do not stop the Covalent server while you have running workflows. Stopping the server will kill the workflows." was included twice on [this page](https://covalent.readthedocs.io/en/latest/getting_started/first_experiment/index.html). The second instance doesn't seem like the best spot to include it, because it might scare the user into thinking closing their Python console or killing their Jupyter kernel will kill the server.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation and CHANGELOG accordingly.
- [X] I have read the CONTRIBUTING document.
