### PR TITLE
fixing executor data inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reverted file-lock changes
 - Fixed dispatches list UI api caused by pydantic config.
 - Fixed graph API.
+- Executor and workflow executor data dictionaries are passed to sublattices
 
 ## [0.227.0-rc.0] - 2023-06-13
 

--- a/covalent/_shared_files/defaults.py
+++ b/covalent/_shared_files/defaults.py
@@ -178,7 +178,9 @@ class DefaultConfig:
 @dataclass
 class DefaultMetadataValues:
     executor: str = field(default_factory=get_default_executor)
+    executor_data: Dict = field(default_factory=dict)
     deps: Dict = field(default_factory=dict)
     call_before: List = field(default_factory=list)
     call_after: List = field(default_factory=list)
     workflow_executor: str = field(default_factory=get_default_executor)
+    workflow_executor_data: Dict = field(default_factory=dict)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->
This PR fixes a bug related to executor attribute inheritance.  Previously, if an executor class object was assigned to a lattice's executor or workflow_executor, only the string name would be passed to sublattices, leading to errors such as #1733 and https://github.com/AgnostiqHQ/covalent-slurm-plugin/issues/70.  This small change fixes this so that the dictionary of class metadata is also passed to sublattices.

After this fix, the following examples should work:

1. Executor inheritance
```
# MyExecutor is used for all electrons at any level of nesting
# Dask will be used as the workflow executor

executor = MyExecutor(param1, param2)

@ct.electron
def task():
    return

@ct.electron
@ct.lattice
def sublattice():
    return task()

@ct.lattice(executor=executor)
def workflow():
    return sublattice()
```

2. Workflow executor inheritance
```
# Both the top-level lattice and the sublattice use MyExecutor for postprocessing
@ct.lattice(workflow_executor=executor)
def workflow():
    return sublattice()
```

3. Override the default executor in a sublattice
```
# The sublattice's tasks will now use the local executor
# Any further levels of nesting will also use "local"
@ct.electron
@ct.lattice(executor="local")
def sublattice():
    return task()

@ct.lattice(executor=executor)
def workflow():
    return sublattice()
```

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
