### PR TITLE
Update qelectron_utils module for remote QElectron execution

### DIFF
--- a/covalent/_shared_files/qelectron_utils.py
+++ b/covalent/_shared_files/qelectron_utils.py
@@ -98,7 +98,7 @@ def extract_qelectron_db(s: Union[None, str]) -> Tuple[str, bytes]:
     data_pattern = f".*{_QE_DB_DATA_MARKER}(.*){_QE_DB_DATA_MARKER}.*"
     if not s or not (_matches := re.findall(data_pattern, s)):
         app_log.debug(f"No Qelectron data detected in '{s!s}'")
-        return s, b''
+        return s, b""
 
     # Load qelectron data and convert back to bytes.
     app_log.debug("Detected Qelectron output data")
@@ -156,11 +156,15 @@ def write_qelectron_db(
     task_subdir = _get_qelectron_db_subdir(dispatch_id, node_id)
     data_mdb_path = task_subdir / _DATA_FILENAME
     if task_subdir.exists():
-        app_log.debug(f"Task subdirectory already exists in qelectron_db_path: {str(data_mdb_path)}")
+        app_log.debug(
+            f"Task subdirectory already exists in qelectron_db_path: {str(data_mdb_path)}"
+        )
     else:
         # Create task subdirectory.
         task_subdir.mkdir(parents=True)
-        app_log.debug(f"Writing Qelectron database file in qelectron_db_path: {str(data_mdb_path)}")
+        app_log.debug(
+            f"Writing Qelectron database file in qelectron_db_path: {str(data_mdb_path)}"
+        )
 
         # Write "data.mdb" file.
         with open(data_mdb_path, "wb") as server_data_mdb_file:


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

Related PR for AWSBatch Executor: https://github.com/AgnostiqHQ/covalent-awsbatch-plugin/pull/79

Because the QServer is a fully-local object here, remotely executed QElectrons end up creating database entries (inside the `"qelectron_db_dir"`) *on the remote*. This means that database will be missing on covalent server, and the QElectron UI elements will therefore not work.

What we do here is to create the `"qelectron_db_dir"` (if it does not exist) when creating the `"results_dir"` entry. The former is for the QServer (and `Database`, and therefore the UI), while the latter is for the Covalent Server.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
