### PR TITLE
Modify `Electrons` to use Covalent server's QElectron DBs, instead of QServer QElectron DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Electron DAL to use Covalent server's data instead of QServer's data.
+
 ### Added
 
 - Corrected support from distributed Hamiltonian expval calculations
@@ -14,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UI changes added for qelectrons and fix for related config file corruption
 - UI fix regarding Qelectron not showing up
 - Performance optimisation of UI for large Qelectrons
-- 
+
 ## Tests
 
 - Changed the method for startup and shutdown events for pytest to work with fastapi version 0.93.0

--- a/covalent/_shared_files/qelectron_utils.py
+++ b/covalent/_shared_files/qelectron_utils.py
@@ -92,10 +92,10 @@ def remove_qelectron_db(output: str):
     Replace the Qelectron DB string in `s` with the empty string.
 
     Arg:
-        s:
+        output: captured stdout string
 
     Return:
-        the string `s` without any Qelectron database
+        the output string without QElectron database removed
     """
     output = re.sub(f"{_QE_DB_DATA_MARKER}.*{_QE_DB_DATA_MARKER}", "", output)
     return output.strip()
@@ -112,10 +112,13 @@ def write_qelectron_db(
 
     That is, creates the tree
 
-    .database
-    └── <dispatch-id>
-        └── <node-id>
-            └── data.mdb
+    covalent
+    └── data
+        └── <dispatch-id>
+            └── .database
+                └── <dispatch-id>  # redundant hierarchy here to mimic QServer DB
+                    └── <node-id>
+                        └── data.mdb
 
     inside the `results_dir/dispatch_id`.
     """

--- a/covalent_ui/api/v1/data_layer/electron_dal.py
+++ b/covalent_ui/api/v1/data_layer/electron_dal.py
@@ -295,7 +295,9 @@ class Electrons:
         if not is_qa_electron:
             return None
         qdb_path = _path_to_qelectron_db(dispatch_id=str(dispatch_id))
-        return len(Database(qdb_path).get_circuit_ids(dispatch_id=str(dispatch_id), node_id=node_id))
+        return len(
+            Database(qdb_path).get_circuit_ids(dispatch_id=str(dispatch_id), node_id=node_id)
+        )
 
     def get_avg_quantum_calls(self, dispatch_id, node_id, is_qa_electron: bool):
         if not is_qa_electron:


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

The main issue here is that `Database()` by default points to data inside `~/.local/share/covalent/qelectron_db`. This folder belongs to the QServer.

We should instead use the transferred data in `~/.local/share/covalent/data/<dispatch_id>`, **because the former will NOT exist if the QElectron-containing electron is executed non-locally.**

**Solution:**

With the changes here, we still use the `Database` class to interface with the `.mdb` files. However, we don't have a *single* instance (no more `self.qdb`) that accesses an *single* directory (by default the undesired `~/.local/share/covalent/qelectron_db`).

Instead we specify the directory (i.e. `~/.local/share/covalent/data/<dispatch_id>/...`) every time we need to access *a* (one of arbitrarily many) QElectron database in the Covalent server's data folder.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
