### PR TITLE
Update `requirements.txt` to update pydantic minimum version and put `py.typed` in `MANIFEST.in`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Added a `py.typed` file to support type-checking
 
 ### Changed
 
 - Raised the minimum version of Pydantic from 1.10.1 to 2.1.1 in `requirements.txt`
-
-### Added
-
-- Added a `py.typed` file to support type-checking
 
 ## [0.228.0-rc.0] - 2023-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Raised the minimum version of Pydantic from 1.10.1 to 2.1.1 in `requirements.txt`
+
 ## [0.228.0-rc.0] - 2023-08-31
 
 ### Authors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+
 ### Changed
 
 - Raised the minimum version of Pydantic from 1.10.1 to 2.1.1 in `requirements.txt`
 
-## Added
+### Added
 
 - Added a `py.typed` file to support type-checking
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include VERSION
 include requirements.txt
 include requirements-client.txt
+include covalent/py.typed
 recursive-include covalent/executor/executor_plugins/ *
 recursive-include covalent_dispatcher/_service/ *
 recursive-include covalent_migrations/ *

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ furl>=2.1.3
 natsort>=8.4.0
 networkx>=2.8.6
 psutil>=5.9.0
-pydantic>=1.10.1
+pydantic>=2.1.1
 python-socketio>=5.7.1
 requests>=2.24.0
 rich>=12.0.0,<=13.3.5


### PR DESCRIPTION
- [] I have added the tests to cover my changes.
- [X] I have updated the documentation and CHANGELOG accordingly.
- [X] I have read the CONTRIBUTING document.

Closes #1765. Essentially, the existing minimum version for Pydantic causes the UI not to render appropriately. Pydantic > 2 is needed now for Covalent. As such, I have set the minimum version to 2.1.1. I chose 2.1.1 intentionally because: a) I tested it and it works; b) FastAPI strictly does not support 2.0.0, 2.0.1, or 2.1.0 so we can't use 2.0 through 2.1.0 anyway.