### PR TITLE
Exclude `aiohttp` 4.0.0a* in `requirements.txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Excluded 4.0.0a* versions of aiohttp in `requirements.txt` 
 - Raised the minimum version of Pydantic from 1.10.1 to 2.1.1 in `requirements.txt`
 - Electron DAL to use Covalent server's data instead of QServer's data.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiofiles>=0.8.0,!=4.0.0a0,!=4.0.0a1
-aiohttp>=3.8.1
+aiofiles>=0.8.0
+aiohttp>=3.8.1,!=4.0.0a0,!=4.0.0a1
 alembic>=1.8.0
 click>=8.1.3
 cloudpickle>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiofiles>=0.8.0,!=4.0.0a*
+aiofiles>=0.8.0,!=4.0.0a0,!=4.0.0a1
 aiohttp>=3.8.1
 alembic>=1.8.0
 click>=8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiofiles>=0.8.0
+aiofiles>=0.8.0,!=4.0.0a*
 aiohttp>=3.8.1
 alembic>=1.8.0
 click>=8.1.3


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

- [ ] I have added the tests to cover my changes.
- [X] I have updated the documentation and CHANGELOG accordingly.
- [X] I have read the CONTRIBUTING document.

For some reason that I have yet to figure out, when I try to do `pip install --no-cache-dir covalent --pre` in a fresh Python 3.10 environment on Linux, it tries to install aiohttp 4.0.0.a1. However, 4.0.0a0 and 4.0.0.a1 are old pre-releases (from 2019) that have broken wheels. In this PR, I excluded these versions from `requirements.txt`.

>  WARNING: Requested aiohttp>=3.8.1 from https://files.pythonhosted.org/packages/f0/f2/703dba52c7620199ea0ec8ea9a4a2f06203b4893b94f60240c2c10225043/aiohttp-4.0.0a1.tar.gz (from covalent), but installing version 4.0.0a1
