### PR TITLE
Fallback to `sh` in remote environment if `bash` not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- check for `/bin/bash` AND `/bin/sh` (in that order) to execute bash leptons
+
 ### Operations
 
 - Change the strict version pin on `pennylane` from `==0.33.1` to `>=0.31.1,<0.33.0`

--- a/covalent/_workflow/lepton.py
+++ b/covalent/_workflow/lepton.py
@@ -343,7 +343,12 @@ class Lepton(Electron):
                 if isinstance(self.command, list):
                     self.command = " && ".join(self.command)
                 self.command = self.command.format(**kwargs)
-                cmd = [shell_executable, "-c", f"{mutated_kwargs} {self.command} {output_string}", "_"]
+                cmd = [
+                    shell_executable,
+                    "-c",
+                    f"{mutated_kwargs} {self.command} {output_string}",
+                    "_",
+                ]
                 cmd += args
                 proc = subprocess.run(cmd, capture_output=True)
             elif self.library_name:

--- a/covalent/_workflow/lepton.py
+++ b/covalent/_workflow/lepton.py
@@ -309,6 +309,15 @@ class Lepton(Electron):
             import builtins
             import subprocess
 
+            shell_executable = None
+            for shell in ["bash", "sh"]:
+                proc = subprocess.run(["which", shell], check=False, capture_output=True)
+                if proc.returncode == 0:
+                    shell_executable = proc.stdout.decode("utf-8").strip()
+                    break
+            if not shell_executable:
+                raise Exception("Could not find a shell.")
+
             mutated_kwargs = ""
             for k, v in kwargs.items():
                 mutated_kwargs += f"export {k}={v} && "
@@ -334,7 +343,7 @@ class Lepton(Electron):
                 if isinstance(self.command, list):
                     self.command = " && ".join(self.command)
                 self.command = self.command.format(**kwargs)
-                cmd = ["/bin/bash", "-c", f"{mutated_kwargs} {self.command} {output_string}", "_"]
+                cmd = [shell_executable, "-c", f"{mutated_kwargs} {self.command} {output_string}", "_"]
                 cmd += args
                 proc = subprocess.run(cmd, capture_output=True)
             elif self.library_name:
@@ -343,7 +352,7 @@ class Lepton(Electron):
                     mutated_args += f'"{arg}" '
 
                 cmd = f"{mutated_kwargs} source {self.library_name} && {self.function_name} {mutated_args} {output_string}"
-                proc = subprocess.run(["/bin/bash", "-c", cmd], capture_output=True)
+                proc = subprocess.run([shell_executable, "-c", cmd], capture_output=True)
             else:
                 raise AttributeError(
                     "Shell task does not have enough information to run."

--- a/covalent/_workflow/lepton.py
+++ b/covalent/_workflow/lepton.py
@@ -316,7 +316,7 @@ class Lepton(Electron):
                     shell_executable = proc.stdout.decode("utf-8").strip()
                     break
             if not shell_executable:
-                raise Exception("Could not find a shell.")
+                raise Exception("Could not find a shell on remote.")
 
             mutated_kwargs = ""
             for k, v in kwargs.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiofiles>=0.8.0
 aiohttp>=3.8.1
 alembic>=1.8.0
+boto3>=1.26.110
 click>=8.1.3
 cloudpickle>=2.0.0,<3
 dask[distributed]>=2022.6.0

--- a/tests/covalent_tests/workflow/lepton_test.py
+++ b/tests/covalent_tests/workflow/lepton_test.py
@@ -505,6 +505,22 @@ def test_shell_wrapper(
     assert result == expected_return
 
 
+def test_shell_wrapper_no_shell_exception(mocker):
+    """
+    Test that an exception is raised if no shell is available.
+    """
+    from collections import namedtuple
+
+    lepton = Lepton(language="bash", command="hostname")
+    task = lepton.wrap_task()
+
+    fake_proc = namedtuple("FakeProc", ["returncode"])(1)
+    mocker.patch("subprocess.run", return_value=fake_proc)
+
+    with pytest.raises(Exception, match="Could not find a shell on remote."):
+        task()
+
+
 def test_lepton_constructor_serializes_metadata():
     le = LocalExecutor()
     bashdep = DepsBash(["yum install gcc"])

--- a/tests/functional_tests/lepton_test.py
+++ b/tests/functional_tests/lepton_test.py
@@ -117,31 +117,3 @@ def test_call_dep_retvals_in_lepton():
         dispatch_id = ct.dispatch(ft_workflow)()
         ct.get_result(dispatch_id, wait=True)
         rm._delete_result(dispatch_id)
-
-
-def test_no_shell_exception_in_lepton(mocker):
-    """
-    Test exception raised inside `shell_wrapper` if no shell executable is found.
-    """
-
-    from collections import namedtuple
-
-    @ct.leptons.bash(
-        executor="local",
-        display_name="no_shell_lepton"
-    )
-    def task():
-        return "ls -lth"
-
-    @ct.lattice
-    def no_shell_workflow():
-        return task()
-
-    # To force exception shell-not-found inside `shell_wrapper`.
-    fake_proc = namedtuple("FakeProc", ["returncode"])(1)
-    mocker.patch("subprocess.run", return_value=fake_proc)
-
-    with pytest.raises(Exception):
-        dispatch_id = ct.dispatch(no_shell_workflow)()
-        ct.get_result(dispatch_id, wait=True)
-        rm._delete_result(dispatch_id)

--- a/tests/functional_tests/lepton_test.py
+++ b/tests/functional_tests/lepton_test.py
@@ -117,3 +117,31 @@ def test_call_dep_retvals_in_lepton():
         dispatch_id = ct.dispatch(ft_workflow)()
         ct.get_result(dispatch_id, wait=True)
         rm._delete_result(dispatch_id)
+
+
+def test_no_shell_exception_in_lepton(mocker):
+    """
+    Test exception raised inside `shell_wrapper` if no shell executable is found.
+    """
+
+    from collections import namedtuple
+
+    @ct.leptons.bash(
+        executor="local",
+        display_name="no_shell_lepton"
+    )
+    def task():
+        return "ls -lth"
+
+    @ct.lattice
+    def no_shell_workflow():
+        return task()
+
+    # To force exception shell-not-found inside `shell_wrapper`.
+    fake_proc = namedtuple("FakeProc", ["returncode"])(1)
+    mocker.patch("subprocess.run", return_value=fake_proc)
+
+    with pytest.raises(Exception):
+        dispatch_id = ct.dispatch(no_shell_workflow)()
+        ct.get_result(dispatch_id, wait=True)
+        rm._delete_result(dispatch_id)


### PR DESCRIPTION
There are some cases where the remote environment lacks `/bin/bash`, but may have `/bin/sh` instead.

inside `exec.py`:
```
...
FileNotFoundError: [Errno 2] No such file or directory: '/bin/bash'
```

This PR has some quick changes to make bash lapton execution check for `bash`, then fall back to `sh`, and finally error out if no shell executable is found.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
