### PR TITLE
Patch executor manager to ignore extra plugins discovered during CI tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Operations
+
+- Ignore custom executor plugin in how-to's when running `test_deploy_status` CLI test.
+
 ### Changed
 
 - Terraform output to use scrolling buffer.

--- a/tests/covalent_dispatcher_tests/_cli/cli_test.py
+++ b/tests/covalent_dispatcher_tests/_cli/cli_test.py
@@ -241,11 +241,25 @@ def test_deploy_status(mocker):
     Unit test for `covalent deploy status [executor_name]` command.
     """
 
+    from covalent.executor import _executor_manager
     from covalent_dispatcher._cli.groups.deploy_group import status
 
     # Succeed with empty `executor_names` argument.
+    # Ignoring extra plugin(s) discovered in CI tests environment.
+    filtered_plugins_map = {
+        k: v
+        for k, v in _executor_manager.executor_plugins_map.items()
+        if k not in ["timing_plugin"]
+    }
+    mock_executor_manager = mocker.patch.object(
+        _executor_manager,
+        "executor_plugins_map",
+        return_value=filtered_plugins_map,
+    )
+
     ctx = click.Context(status)
     ctx.invoke(status, executor_names=[])
+    mocker.stop(mock_executor_manager)  # stop ignoring any plugins
 
     # Succeed with invalid `executor_names` argument.
     mock_click_style = mocker.patch("click.style")


### PR DESCRIPTION
Quick fix for this error:
```
ModuleNotFoundError: No module named 'doc/source/how_to/execution/custom_executors/timing_plugin'
```
This happens during `test_deploy_status()` in the CI tests. The reason is that the "timing plugin" created in our how-to's is discovered by `_executor_manager`.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
