### PR TITLE
Remove duplicate `boto3` requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Operations
+
+- Remove `boto3` dependency from `tests/requirements.txt`
+
 ## [0.232.0-rc.0] - 2023-12-01
 
 ### Authors

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-boto3>=1.26.110
 detect-secrets>=1.3.0
 flake8>=5.0.4
 httpx>=0.24.1


### PR DESCRIPTION
There is a boto3 requirement in requirements.txt and in tests/requirements.txt. This will eventually lead to some confusion because it's prone to get out of sync. It is a core dependency, so I kept it in requirements.txt.

- [ ] I have added the tests to cover my changes.
- [X] I have updated the documentation and CHANGELOG accordingly.
- [X] I have read the CONTRIBUTING document.
