### PR TITLE
Do not require dictionary keys to be `str`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -217,9 +217,10 @@ jobs:
         if: env.BUILD_AND_RUN_ALL
         id: covalent_start
         run: |
+          export COVALENT_ENABLE_TASK_PACKING=1
           covalent db migrate
           if [ "${{ matrix.backend }}" = 'dask' ] ; then
-            COVALENT_ENABLE_TASK_PACKING=1 covalent start -d
+            covalent start -d
           elif [ "${{ matrix.backend }}" = 'local' ] ; then
             covalent start --no-cluster -d
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sublattice electron function strings are now parsed correctly
+- The keys of dictionary inputs to electrons no longer need be strings.
+- Fixed inaccuracies in task packing exposed by no longer uploading null attributes upon dispatch.
 
 ### Operations
 
@@ -115,8 +117,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced number of assets to upload when submitting a dispatch.
 - Handled RecursionError on get results for a long running workflow.
 - Fixed functional tests.
-- Fixed inaccuracies in task packing exposed by no longer uploading null attributes upon dispatch.
-- The keys of dictionary inputs to electrons no longer need be strings.
 
 ### Operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handled RecursionError on get results for a long running workflow.
 - Fixed functional tests.
 - Fixed inaccuracies in task packing exposed by no longer uploading null attributes upon dispatch.
+- The keys of dictionary inputs to electrons no longer need be strings.
 
 ### Operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced number of assets to upload when submitting a dispatch.
 - Handled RecursionError on get results for a long running workflow.
 - Fixed functional tests.
+- Fixed inaccuracies in task packing exposed by no longer uploading null attributes upon dispatch.
 
 ### Operations
 

--- a/covalent/_workflow/electron.py
+++ b/covalent/_workflow/electron.py
@@ -572,8 +572,8 @@ class Electron:
 
         elif isinstance(param_value, dict):
 
-            def _auto_dict_node(*args, **kwargs):
-                return dict(kwargs)
+            def _auto_dict_node(keys, values):
+                return {keys[i]: values[i] for i in range(len(keys))}
 
             dict_electron = Electron(
                 function=_auto_dict_node,
@@ -581,7 +581,7 @@ class Electron:
                 task_group_id=self.task_group_id,
                 packing_tasks=True and active_lattice.task_packing,
             )  # Group the auto-generated node with the main node.
-            bound_electron = dict_electron(**param_value)
+            bound_electron = dict_electron(list(param_value.keys()), list(param_value.values()))
             transport_graph.set_node_value(bound_electron.node_id, "name", electron_dict_prefix)
             transport_graph.add_edge(
                 dict_electron.node_id,

--- a/covalent_dispatcher/_dal/importers/result.py
+++ b/covalent_dispatcher/_dal/importers/result.py
@@ -72,7 +72,6 @@ def import_result(
     # Main case: insert new lattice, electron, edge, and job records
 
     storage_path = os.path.join(base_path, dispatch_id)
-    os.makedirs(storage_path)
 
     lattice_record_kwargs = _get_result_meta(res, storage_path, electron_id)
     lattice_record_kwargs.update(_get_lattice_meta(res.lattice, storage_path))
@@ -143,6 +142,7 @@ def _connect_result_to_electron(
         fields={"id", "cancel_requested"},
         equality_filters={"id": parent_electron_record.job_id},
         membership_filters={},
+        for_update=True,
     )[0]
     cancel_requested = parent_job_record.cancel_requested
 

--- a/covalent_dispatcher/_dal/importers/tg.py
+++ b/covalent_dispatcher/_dal/importers/tg.py
@@ -51,7 +51,9 @@ def import_transport_graph(
     # Propagate parent electron id's `cancel_requested` property to the sublattice electrons
     if electron_id is not None:
         parent_e_record = Electron.meta_type.get_by_primary_key(session, electron_id)
-        job_record = Job.get_by_primary_key(session=session, primary_key=parent_e_record.job_id)
+        job_record = Job.get_by_primary_key(
+            session=session, primary_key=parent_e_record.job_id, for_update=True
+        )
         cancel_requested = job_record.cancel_requested
     else:
         cancel_requested = False

--- a/tests/covalent_tests/workflow/electron_test.py
+++ b/tests/covalent_tests/workflow/electron_test.py
@@ -377,18 +377,30 @@ def test_autogen_dict_electrons():
     g = workflow.transport_graph._graph
 
     # Account for postprocessing node
-    assert list(g.nodes) == [0, 1, 2, 3, 4]
+    assert list(g.nodes) == [0, 1, 2, 3, 4, 5, 6, 7, 8]
     fn = g.nodes[1]["function"].get_deserialized()
-    assert fn(x=2, y=5, z=7) == {"x": 2, "y": 5, "z": 7}
-    assert g.nodes[2]["value"].get_deserialized() == 5
-    assert g.nodes[3]["value"].get_deserialized() == 7
+    assert fn(["x", "y", "z"], [2, 5, 7]) == {"x": 2, "y": 5, "z": 7}
+    fn = g.nodes[2]["function"].get_deserialized()
+    assert fn("x", "y") == ["x", "y"]
+    keys = [g.nodes[3]["value"].get_deserialized(), g.nodes[4]["value"].get_deserialized()]
+    fn = g.nodes[5]["function"].get_deserialized()
+    assert fn(2, 3) == [2, 3]
+    vals = [g.nodes[6]["value"].get_deserialized(), g.nodes[7]["value"].get_deserialized()]
+    assert keys == ["x", "y"]
+    assert vals == [5, 7]
     assert set(g.edges) == {
         (1, 0, 0),
         (2, 1, 0),
-        (3, 1, 0),
-        (0, 4, 0),
-        (0, 4, 1),
-        (1, 4, 0),
+        (3, 2, 0),
+        (4, 2, 0),
+        (5, 1, 0),
+        (6, 5, 0),
+        (7, 5, 0),
+        (0, 8, 0),
+        (0, 8, 1),
+        (1, 8, 0),
+        (2, 8, 0),
+        (5, 8, 0),
     }
 
 

--- a/tests/functional_tests/workflow_stack_test.py
+++ b/tests/functional_tests/workflow_stack_test.py
@@ -800,7 +800,8 @@ def test_workflows_with_dict_nodes():
         res_1 = sum_values(x)
         return square(res_1)
 
-    dispatch_id = ct.dispatch(workflow)({"x": 1, "y": 2, "z": 3})
+    # Check that non-string keys are allowed
+    dispatch_id = ct.dispatch(workflow)({"x": 1, "y": 2, 3: 3})
 
     res_obj = rm.get_result(dispatch_id, wait=True)
 


### PR DESCRIPTION
The collector electron now assembles the dictionary from two lists -- one list of keys, one list of corresponding values.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.

Closes #1937 .