### PR TITLE
Unbreak task packing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,9 +209,10 @@ jobs:
         if: env.BUILD_AND_RUN_ALL
         id: covalent_start
         run: |
+          export COVALENT_ENABLE_TASK_PACKING=1
           covalent db migrate
           if [ "${{ matrix.backend }}" = 'dask' ] ; then
-            COVALENT_ENABLE_TASK_PACKING=1 covalent start -d
+            covalent start -d
           elif [ "${{ matrix.backend }}" = 'local' ] ; then
             covalent start --no-cluster -d
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reduced number of assets to upload when submitting a dispatch.
+- Fixed inaccuracies in task packing exposed by no longer uploading null attributes upon dispatch.
 
 ### Operations
 

--- a/tests/functional_tests/file_transfer_test.py
+++ b/tests/functional_tests/file_transfer_test.py
@@ -180,7 +180,9 @@ def test_local_file_transfer_collected_nodes(tmp_path: Path):
     rm._delete_result(dispatch_id)
 
     assert len(workflow_result.result) == 2
-    assert workflow_result.result == (MOCK_CONTENTS, MOCK_CONTENTS)
+    assert workflow_result.result[0] == MOCK_CONTENTS
+    assert workflow_result.result[1] == MOCK_CONTENTS
+
     for f in [source_file_1, dest_file_1, source_file_2, dest_file_2]:
         f.unlink()
 


### PR DESCRIPTION
When submitting a task group, only attempt to upload task inputs corresponding to nodes external to the task group since only those will have been resolved.

This error was exposed by the recent change to stop uploading null attributes of electrons during dispatch. Previously the outputs of electrons -- even those that had not run yet -- were initialized to a non-null default value and then replaced during task execution.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
