### PR TITLE
Removing my email from the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Authors
 
-- Andrew S. Rosen <asrosen93@gmail.com>
+- Andrew S. Rosen (@Andrew_S_Rosen)
 - Casey Jao <casey@agnostiq.ai>
 - Sankalp Sanand <sankalp@agnostiq.ai>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Co-authored-by: batchumanish <126003896+batchumanish@users.noreply.github.com>
 - Co-authored-by: Santosh kumar <29346072+santoshkumarradha@users.noreply.github.com>
 - Ara Ghukasyan <38226926+araghukas@users.noreply.github.com>
-
 
 ### Operations
 
@@ -71,13 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Authors
 
-- Andrew S. Rosen <asrosen93@gmail.com>
+- Andrew S. Rosen (@Andrew_S_Rosen)
 - Casey Jao <casey@agnostiq.ai>
 - Sankalp Sanand <sankalp@agnostiq.ai>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
 - ArunPsiog <106462226+ArunPsiog@users.noreply.github.com>
 - Co-authored-by: Ara Ghukasyan <ara@agnostiq.ai>
-
 
 ### Added
 
@@ -96,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pack deps, call_before, and call_after assets into one file.
 - Changed handling of tuples and sets when building the transport graph - they will be converted to electron lists as well for now
 - `qelectron_db`, `qelectron_data_exists`, `python_version`, and `covalent_version`
-   are now optional in the pydantic model definitions.
+  are now optional in the pydantic model definitions.
 
 ### Fixed
 
@@ -115,7 +113,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ara Ghukasyan <38226926+araghukas@users.noreply.github.com>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-
 
 ### Operations
 
@@ -150,7 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Authors
 
-- Andrew S. Rosen <asrosen93@gmail.com>
+- Andrew S. Rosen (@Andrew_S_Rosen)
 - Co-authored-by: Will Cunningham <wjcunningham7@users.noreply.github.com>
 - Co-authored-by: Sankalp Sanand <sankalp@agnostiq.ai>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
@@ -177,8 +174,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Co-authored-by: Ara Ghukasyan <ara@agnostiq.ai>
 - Co-authored-by: Alejandro Esquivel <ae@alejandro.ltd>
 
-
-
 ### Added
 
 - Programmatic equivalents of CLI commands `covalent start` and `covalent stop`
@@ -196,7 +191,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing guidelines steps for installing for the first time
 - Updated gitignore to ignore yarn files and folders for latest version of yarn
 - Fixed the bug that caused ValueError error when using KEYWORD_ONLY parameter in electron func
-- Changed code at line 218 in covalent/_shared_files/utils.py
+- Changed code at line 218 in covalent/\_shared_files/utils.py
 - Fixed usage of deprecated pydantic validation methods
 - Fixed qelectron_db retrieval in result object
 - Fixed editability of Qelectron on settings page - UI changes
@@ -257,7 +252,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Authors
 
-- Andrew S. Rosen <asrosen93@gmail.com>
+- Andrew S. Rosen (@Andrew_S_Rosen)
 - Alejandro Esquivel <ae@alejandro.ltd>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
 - Co-authored-by: mpvgithub <107603631+mpvgithub@users.noreply.github.com>
@@ -316,7 +311,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Authors
 
-- Andrew S. Rosen <asrosen93@gmail.com>
+- Andrew S. Rosen (@Andrew_S_Rosen)
 - Co-authored-by: Sankalp Sanand <sankalp@agnostiq.ai>
 - Will Cunningham <wjcunningham7@users.noreply.github.com>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
@@ -406,7 +401,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Authors
 
-- Andrew S. Rosen <asrosen93@gmail.com>
+- Andrew S. Rosen (@Andrew_S_Rosen)
 - Co-authored-by: Sankalp Sanand <sankalp@agnostiq.ai>
 - Will Cunningham <wjcunningham7@users.noreply.github.com>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
@@ -448,7 +443,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prasanna Venkatesh <54540812+Prasy12@users.noreply.github.com>
 - Co-authored-by: kamalesh.suresh <kamalesh.suresh@psiog.com>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-- Co-authored-by: Andrew S. Rosen <asrosen93@gmail.com>
+- Co-authored-by: Andrew S. Rosen (@Andrew_S_Rosen)
 - Faiyaz Hasan <faiyaz@agnostiq.ai>
 - Co-authored-by: sriranjani venkatesan <sriranjani.venkatesan@psiog.com>
 - Will Cunningham <wjcunningham7@users.noreply.github.com>
@@ -469,7 +464,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prasanna Venkatesh <54540812+Prasy12@users.noreply.github.com>
 - Co-authored-by: kamalesh.suresh <kamalesh.suresh@psiog.com>
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-- Co-authored-by: Andrew S. Rosen <asrosen93@gmail.com>
+- Co-authored-by: Andrew S. Rosen (@Andrew_S_Rosen)
 - Faiyaz Hasan <faiyaz@agnostiq.ai>
 - Co-authored-by: sriranjani venkatesan <sriranjani.venkatesan@psiog.com>
 - Will Cunningham <wjcunningham7@users.noreply.github.com>
@@ -531,7 +526,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sankalp Sanand <sankalp@agnostiq.ai>
 - Co-authored-by: kessler-frost <ssanand@hawk.iit.edu>
 - Faiyaz Hasan <faiyaz@agnostiq.ai>
-- Andrew S. Rosen <asrosen93@gmail.com>
+- Andrew S. Rosen (@Andrew_S_Rosen)
 - Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
 - Co-authored-by: Santosh kumar <29346072+santoshkumarradha@users.noreply.github.com>
 


### PR DESCRIPTION
This PR is to remove my email from the `CHANGELOG` and to replace it with my GitHub username.

When searching for my email via Google, the [only hit](https://www.google.com/search?q=%22asrosen93%40gmail.com%22) is for the Covalent `CHANGELOG`. I've been getting a lot of spam in the last several days, so I would like to clean up this public trace of my email just in case. I have replaced my email with my GitHub username.

By default, it may be worth considering using usernames by default in the `CHANGELOG`. In any case, I'm aware that this is an automated process so this PR is only a band-aid solution. I wasn't sure where to adjust the automated procedure. Also, this PR will obviously fail for updating the `CHANGELOG`.