### PR TITLE
Making qelectron import within try except.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Ignoring all errors when importing qelectrons instead of only `ImportError`
+
 ## [0.235.0-rc.0] - 2024-05-29
 
 ### Authors

--- a/covalent/__init__.py
+++ b/covalent/__init__.py
@@ -52,7 +52,7 @@ from ._workflow.electron import wait  # nopycln: import
 from .executor.utils import get_context  # nopycln: import
 
 try:
-    # try to load qelectron modules 
+    # try to load qelectron modules
     from ._workflow.qelectron import qelectron  # nopycln: import
     from .quantum import QCluster  # nopycln: import
 except:

--- a/covalent/__init__.py
+++ b/covalent/__init__.py
@@ -51,12 +51,10 @@ from ._workflow import (  # nopycln: import
 from ._workflow.electron import wait  # nopycln: import
 from .executor.utils import get_context  # nopycln: import
 
-try:
+with contextlib.suppress(Exception):
     # try to load qelectron modules
     from ._workflow.qelectron import qelectron  # nopycln: import
     from .quantum import QCluster  # nopycln: import
-except:
-    pass
 
 __all__ = [s for s in dir() if not s.startswith("_")]
 

--- a/covalent/__init__.py
+++ b/covalent/__init__.py
@@ -51,9 +51,12 @@ from ._workflow import (  # nopycln: import
 from ._workflow.electron import wait  # nopycln: import
 from .executor.utils import get_context  # nopycln: import
 
-with contextlib.suppress(ImportError):
+try:
+    # try to load qelectron modules 
     from ._workflow.qelectron import qelectron  # nopycln: import
     from .quantum import QCluster  # nopycln: import
+except:
+    pass
 
 __all__ = [s for s in dir() if not s.startswith("_")]
 


### PR DESCRIPTION
Moving the suppression of import error to try to deal with other errors until we update PennyLane for qelectron. This solves the conflict of importing covalent prerelease with the latest PennyLane, barring which you get stuck.

```python
AttributeError: type object 'DefaultQubit' has no attribute 'operations'
```

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
