### PR TITLE
Default workflow_executor to lattice-default executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- workflow_executor now defaults to the lattice-default executor
+
 ## [0.236.0-rc.0] - 2025-01-21
 
 ### Authors

--- a/covalent/_shared_files/defaults.py
+++ b/covalent/_shared_files/defaults.py
@@ -198,5 +198,3 @@ class DefaultMetadataValues:
     executor: str = field(default_factory=get_default_executor)
     executor_data: Dict = field(default_factory=dict)
     hooks: Dict = field(default_factory=dict)
-    workflow_executor: str = field(default_factory=get_default_executor)
-    workflow_executor_data: Dict = field(default_factory=dict)

--- a/covalent/_workflow/electron.py
+++ b/covalent/_workflow/electron.py
@@ -208,18 +208,11 @@ class Electron:
         # enclosing lattice's workflow_executor.
 
         metadata = encode_metadata(DEFAULT_METADATA_VALUES.copy())
-        executor = metadata["workflow_executor"]
-        executor_data = metadata["workflow_executor_data"]
-
         op_electron = Electron(func_for_op, metadata=metadata)
 
         if active_lattice := active_lattice_manager.get_active_lattice():
-            executor = active_lattice.metadata.get(
-                "workflow_executor", metadata["workflow_executor"]
-            )
-            executor_data = active_lattice.metadata.get(
-                "workflow_executor_data", metadata["workflow_executor_data"]
-            )
+            executor = active_lattice.metadata["workflow_executor"]
+            executor_data = active_lattice.metadata["workflow_executor_data"]
             op_electron.metadata["executor"] = executor
             op_electron.metadata["executor_data"] = executor_data
 

--- a/covalent/_workflow/lattice.py
+++ b/covalent/_workflow/lattice.py
@@ -204,16 +204,22 @@ class Lattice:
         self.inputs = TransportableObject({"args": args, "kwargs": kwargs})
 
         # Set any lattice metadata not explicitly set by the user
-        constraint_names = {"executor", "workflow_executor", "hooks"}
+        constraint_names = {"executor", "hooks"}
         new_metadata = {
             name: DEFAULT_METADATA_VALUES[name]
             for name in constraint_names
             if self.metadata[name] is None
         }
+
         new_metadata = encode_metadata(new_metadata)
 
         for k, v in new_metadata.items():
             self.metadata[k] = v
+
+        # Copy lattice default executor to workflow_executor if the latter is not set
+        if self.metadata["workflow_executor"] is None:
+            self.metadata["workflow_executor"] = self.metadata["executor"]
+            self.metadata["workflow_executor_data"] = self.metadata["executor_data"]
 
         # Check whether task packing is enabled
         self._task_packing = get_config("sdk.task_packing") == "true"

--- a/tests/covalent_tests/workflow/electron_metadata_test.py
+++ b/tests/covalent_tests/workflow/electron_metadata_test.py
@@ -17,7 +17,7 @@
 """Unit tests to test whether electrons inherit lattice metadata correctly"""
 
 
-from covalent._shared_files.defaults import get_default_executor, postprocess_prefix
+from covalent._shared_files.defaults import postprocess_prefix
 from covalent._workflow.transport import _TransportGraph
 
 
@@ -51,7 +51,8 @@ def test_electrons_get_lattice_metadata_1():
         metadata = tg.get_node_value(node_id, "metadata")
         node_name = tg.get_node_value(node_id, "name")
         if node_name.startswith(postprocess_prefix):
-            assert metadata["executor"] == get_default_executor()
+            # workflow_executor defaults to lattice-default executor
+            assert metadata["executor"] == "awslambda"
         elif "parameter" not in node_name:
             assert metadata["executor"] == "electron_executor"
             assert metadata["hooks"]["deps"]["bash"] == electron_bash_dep.to_dict()

--- a/tests/covalent_tests/workflow/lattice_test.py
+++ b/tests/covalent_tests/workflow/lattice_test.py
@@ -69,7 +69,7 @@ def test_lattice_workflow_executor_settings():
 
     assert not workflow.metadata["workflow_executor"]
     workflow.build_graph(1)
-    assert workflow.metadata["workflow_executor"] == DEFAULT_METADATA_VALUES["workflow_executor"]
+    assert workflow.metadata["workflow_executor"] == workflow.metadata["executor"]
     workflow_2.build_graph(1)
     assert workflow_2.metadata["workflow_executor"] == "custom_postprocessor"
 


### PR DESCRIPTION
This should eliminate the need to set workflow_executor explicitly in many cases.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
