### PR TITLE
Fix redispatch bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed various 422 errors by setting additional `Content-Type: application/json` headers as necessary
 - Moved `locust` out of `tests/requirements.txt` into the benchmark workflow only, to avoid a `gevent` conflict
 - Various test fixes: renamed `status` → `job_status`, corrected mock paths, updated graph key references
+- Fix redispatch bug
 
 ## [0.240.0-rc.0] - 2025-05-14
 

--- a/covalent/_shared_files/defaults.py
+++ b/covalent/_shared_files/defaults.py
@@ -31,7 +31,8 @@ except ImportError:
 
 prefix_separator = ":"
 
-parameter_prefix = f"{prefix_separator}parameter{prefix_separator}"
+NODE_TYPE_PARAMETER = "parameter"
+parameter_prefix = f"{prefix_separator}{NODE_TYPE_PARAMETER}{prefix_separator}"
 electron_list_prefix = f"{prefix_separator}electron_list{prefix_separator}"
 electron_dict_prefix = f"{prefix_separator}electron_dict{prefix_separator}"
 subscript_prefix = f"{prefix_separator}subscripted{prefix_separator}"

--- a/covalent_dispatcher/_dal/importers/result.py
+++ b/covalent_dispatcher/_dal/importers/result.py
@@ -251,8 +251,10 @@ def handle_redispatch(
     tg_new = result_object.lattice.transport_graph
     tg_old = parent_result_object.lattice.transport_graph
 
-    # Get the nodes that can potentially be reused from the previous
-    # dispatch, assuming that they have previously completed.
+    # Get the nodes that can potentially be reused from the previous dispatch,
+    # assuming that they have previously completed. A node is "reusable" if its
+    # task definition is unchanged and its functional dependencies are
+    # recursively recursively reusable.
     reusable_nodes = TransportGraphOps(tg_old).get_reusable_nodes(tg_new)
 
     # No need to upload assets for reusable nodes since they can be
@@ -274,7 +276,7 @@ def handle_redispatch(
 
     # Two cases:
     #
-    # If not reuse_previous_results, copy assets for all reusable
+    # If reuse_previous_results=False, copy assets for all reusable
     # nodes but leave all metadata as initialized by the SDK.  This
     # will cause all nodes to be rerun since their statuses will be
     # NEW_OBJECT.
@@ -287,8 +289,7 @@ def handle_redispatch(
     assets_to_copy = TransportGraphOps(tg_new).copy_nodes_from(
         tg_old,
         reusable_nodes,
-        copy_metadata=reuse_previous_results,
-        defer_copy_objects=True,
+        reuse_previous_results=reuse_previous_results,
     )
 
     # Since the graph comparison is finished, we can upgrade

--- a/covalent_dispatcher/_dal/tg_ops.py
+++ b/covalent_dispatcher/_dal/tg_ops.py
@@ -22,6 +22,7 @@ from typing import Callable, List
 import networkx as nx
 
 from covalent._shared_files import logger
+from covalent._shared_files.defaults import NODE_TYPE_PARAMETER
 from covalent._shared_files.util_classes import RESULT_STATUS
 
 from .asset import copy_asset_meta
@@ -29,6 +30,9 @@ from .electron import ASSET_KEYS, METADATA_KEYS
 from .tg import _TransportGraph
 
 app_log = logger.app_log
+
+
+GENERATED_ASSETS = {"output", "stdout", "stderr", "error"}
 
 
 class TransportGraphOps:
@@ -73,18 +77,31 @@ class TransportGraphOps:
         tg: _TransportGraph,
         nodes,
         *,
-        copy_metadata: bool = True,
-        defer_copy_objects: bool = False,
+        reuse_previous_results: bool = True,
     ) -> List:
-        """Copy nodes from the transport graph in the argument."""
+        """Shallow-copy nodes from the transport graph in the argument.
+
+        Parameters:
+            `tg`: The graph representing a previously run workflow
+            `nodes`: A list of nodes logically unchanged from the previous graph
+
+        `nodes` will be a list of electrons with the same definitions and logical dependencies
+        (recursively up to the root) in the original and new dispatch.
+
+        Optional parameters:
+            `reuse_previous_results`: Indicates whether the nodes will be skipped in the redispatch. If False,
+            only copy the task definitions and not their outputs.
+
+        """
 
         assets_to_copy = []
 
         for n in nodes:
             old_node = tg.get_node(n)
             old_status = tg.get_node_value(n, "status")
+            node_type = tg.get_node_value(n, "type")
 
-            if copy_metadata and old_status == RESULT_STATUS.COMPLETED:
+            if reuse_previous_results and old_status == RESULT_STATUS.COMPLETED:
                 # Only previously completed nodes can actually be
                 # reused
 
@@ -100,7 +117,17 @@ class TransportGraphOps:
             # TODO: Use the ElectronAssets link table as the source of
             # truth instead of these hardcoded values
             for k in ASSET_KEYS:
-                # Copy asset metadata
+                # Copy asset metadata For non-parameter nodes, skip output,
+                # stdout, stderr, error if previous results are not to be reused
+                # since the re-run will overwrite artifacts produced by the
+                # previous workflow run.
+                if (
+                    (not reuse_previous_results)
+                    and k in GENERATED_ASSETS
+                    and node_type != NODE_TYPE_PARAMETER
+                ):
+                    app_log.debug(f"Not copying asset {k} for node {n}")
+                    continue
                 app_log.debug(f"Copying asset {k} for node {n}")
                 with old_node.session() as session:
                     old = old_node.get_asset(k, session)

--- a/covalent_dispatcher/_service/app.py
+++ b/covalent_dispatcher/_service/app.py
@@ -208,8 +208,15 @@ async def register_redispatch(
         reuse_previous_results: Whether to try reusing the results of
             previously completed electrons.
 
+    The dispatcher will avoid asking the client to re-upload artifacts
+    it determines can be reused from the original dispatch. The status
+    `"PENDING_REPLACEMENT"` indicates that a task's definition has
+    changed from the original dispatch, hence that new uploads are
+    required.
+
     Returns:
         The manifest with `dispatch_id` and remote URIs for each asset populated.
+
     """
     try:
         return await dispatcher.register_redispatch(

--- a/tests/covalent_dispatcher_tests/_dal/tg_ops_test.py
+++ b/tests/covalent_dispatcher_tests/_dal/tg_ops_test.py
@@ -245,6 +245,7 @@ def test_copy_nodes_from(tg, mocker):
         0,
         name="replacement",
         function=replacement,
+        type="function",
         status=RESULT_STATUS.COMPLETED,
         metadata={"0-mock-key": "0-mock-value"},
     )
@@ -252,6 +253,7 @@ def test_copy_nodes_from(tg, mocker):
         1,
         name="multiply",
         function=multiply,
+        type="function",
         status=RESULT_STATUS.NEW_OBJECT,
         metadata={"1-mock-key": "1-mock-value"},
     )
@@ -259,6 +261,7 @@ def test_copy_nodes_from(tg, mocker):
         2,
         name="replacement",
         function=replacement,
+        type="function",
         status=RESULT_STATUS.COMPLETED,
         metadata={"2-mock-key": "2-mock-value"},
     )

--- a/tests/functional_tests/workflow_stack_test.py
+++ b/tests/functional_tests/workflow_stack_test.py
@@ -816,6 +816,42 @@ def test_redispatch():
     assert res_obj_5.result == 49
 
 
+def test_redispatch_doesnt_overwrite_previous_outputs():
+
+    # Use an impure function
+    @ct.lattice
+    @ct.electron
+    def read_from_file(filename: str) -> str:
+        with open(filename, "r") as f:
+            return f.read()
+
+    t = tempfile.NamedTemporaryFile(mode="w+")
+
+    t.write("run_1")
+    t.flush()
+
+    dispatch_id = ct.dispatch(read_from_file)(t.name)
+    orig_res = ct.get_result(dispatch_id, wait=True)
+    assert orig_res.status == "COMPLETED"
+    assert orig_res.result == "run_1"
+
+    # Modify the file and redispatch
+    t.seek(0)
+    t.write("run_2")
+    t.flush()
+
+    redispatch_id = ct.redispatch(dispatch_id, reuse_previous_results=False)()
+    redispatch_res = ct.get_result(redispatch_id, wait=True)
+    assert redispatch_res.status == "COMPLETED"
+    assert redispatch_res.result == "run_2"
+
+    # Check that the original dispatch's outputs remain unchanged
+    # Redownload the results
+    orig_res = ct.get_result(dispatch_id)
+    assert orig_res.get_node_result(0)["output"].get_deserialized() == "run_1"
+    assert orig_res.result == "run_1"
+
+
 def test_redispatch_reusing_previous_results():
     """Test reusing previous results for redispatching"""
 


### PR DESCRIPTION
When users redispatch a previously run workflow, the server performs server-side copies of some data from the previous run to the new run to save clients from having to re-upload task definitions that haven't changed from the previous workflow.

In the interest of efficiency, deep copies were changed some time ago to shallow copies (DB references only). Unfortunately, this also introduced a bug as demonstrated by the included test case: unless all functions in the workflow are pure, shallow copies are only safe for immutable artifacts.

Unless the user specifies `reuse_previous_results=True`, only shallow-copy task definitions to prevent the next run from overwriting artifacts generated by the previous workflow run.


<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Add a note to /CHANGELOG.md summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Ensure that your branch is up-to-date with the base branch.
-->

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
