### PR TITLE
fix: Rsync error for remote dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed various 422 errors by setting additional `Content-Type: application/json` headers as necessary
 - Moved `locust` out of `tests/requirements.txt` into the benchmark workflow only, to avoid a `gevent` conflict
 - Various test fixes: renamed `status` → `job_status`, corrected mock paths, updated graph key references
+- `Rsync` file transfer strategy now logs a warning instead of raising `FileNotFoundError` when the private key is not present locally, so remotely managed dispatchers can reference keys on the machine performing the transfer
 
 ## [0.240.0-rc.0] - 2025-05-14
-
 ### Authors
 
 - Casey Jao <casey@agnostiq.ai>

--- a/covalent/_file_transfer/strategies/rsync_strategy.py
+++ b/covalent/_file_transfer/strategies/rsync_strategy.py
@@ -18,8 +18,11 @@ import os
 from subprocess import PIPE, CalledProcessError, Popen
 from typing import Optional
 
+from ..._shared_files import logger
 from .. import File
 from .transfer_strategy_base import FileTransferStrategy
+
+app_log = logger.app_log
 
 
 class Rsync(FileTransferStrategy):
@@ -43,8 +46,9 @@ class Rsync(FileTransferStrategy):
         self.host = host
 
         if self.private_key_path and not os.path.exists(self.private_key_path):
-            raise FileNotFoundError(
-                f"Provided private key ({self.private_key_path}) does not exist. Could not instantiate Rsync File Transfer Strategy. "
+            app_log.warning(
+                f"Provided private key ({self.private_key_path}) does not exist on this machine. "
+                "The transfer will fail unless the key is available where the transfer is performed."
             )
 
     def get_rsync_ssh_cmd(

--- a/tests/covalent_tests/file_transfer/strategies/rsync_strategy_test.py
+++ b/tests/covalent_tests/file_transfer/strategies/rsync_strategy_test.py
@@ -102,6 +102,19 @@ class TestRsyncStrategy:
                     File("/tmp/source.csv"), File("/tmp/dest.csv")
                 )()
 
+    def test_missing_private_key_warns_instead_of_raising(self, mocker):
+        mocker.patch("os.path.exists", return_value=False)
+        warning_mock = mocker.patch(
+            "covalent._file_transfer.strategies.rsync_strategy.app_log.warning"
+        )
+
+        strategy = Rsync(
+            user=self.MOCK_USER, host=self.MOCK_HOST, private_key_path=self.MOCK_PRIVATE_KEY_PATH
+        )
+
+        assert strategy.private_key_path == self.MOCK_PRIVATE_KEY_PATH
+        warning_mock.assert_called_once()
+
     def test_get_rsync_cmd(self):
         from_file = File("/home/ubuntu/from.csv")
         to_file = File("/home/ubuntu/to.csv")
@@ -112,8 +125,6 @@ class TestRsyncStrategy:
         assert cp_cmd == "rsync -a /home/ubuntu/from.csv /home/ubuntu/to.csv"
 
     def test_get_ssh_rsync_cmd_with_ssh_key(self, mocker):
-        mocker.patch("os.path.exists", return_value=True)
-
         local_file = File(self.MOCK_LOCAL_FILEPATH)
         remote_file = File(self.MOCK_REMOTE_FILEPATH)
         private_key_path = self.MOCK_PRIVATE_KEY_PATH


### PR DESCRIPTION
Fixes #1872

## Root cause

Rsync strategy validates SSH private key path on the client machine

## Changes

- Replaced the hard FileNotFoundError in Rsync.__init__ with an app_log warning so a private key path that only exists where the transfer is executed is accepted, and added a regression unit test.