### PR TITLE
fix: Covalent commands stuck without any way to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed various 422 errors by setting additional `Content-Type: application/json` headers as necessary
 - Moved `locust` out of `tests/requirements.txt` into the benchmark workflow only, to avoid a `gevent` conflict
 - Various test fixes: renamed `status` → `job_status`, corrected mock paths, updated graph key references
+- Config file lock failures now raise a `ConfigLockError` explaining that `COVALENT_CONFIG_DIR` should point to a filesystem supporting file locking, instead of surfacing an opaque `filelock` error
 
 ## [0.240.0-rc.0] - 2025-05-14
-
 ### Authors
 
 - Casey Jao <casey@agnostiq.ai>

--- a/covalent/_shared_files/config.py
+++ b/covalent/_shared_files/config.py
@@ -26,7 +26,11 @@ from typing import Any, Dict, List, Optional, Union
 import filelock
 import toml
 
+from .exceptions import ConfigLockError
+
 """Configuration manager."""
+
+CONFIG_LOCK_TIMEOUT = 1
 
 
 class ConfigManager:
@@ -88,6 +92,9 @@ class ConfigManager:
 
         Returns:
             None
+
+        Raises:
+            ConfigLockError: If the configuration file cannot be locked.
         """
 
         def update_nested_dict(old_dict, new_dict, override_existing: bool = True):
@@ -106,7 +113,8 @@ class ConfigManager:
                         else:
                             old_dict.setdefault(key, value)
 
-        with filelock.FileLock(f"{self.config_file}.lock", timeout=1):
+        lock = self._acquire_config_lock()
+        try:
             with open(self.config_file, "r+") as f:
                 file_config = toml.load(f)
 
@@ -116,6 +124,34 @@ class ConfigManager:
 
                 # Writing it back to the file
                 self.write_config()
+        finally:
+            lock.release()
+
+    def _acquire_config_lock(self) -> filelock.BaseFileLock:
+        """
+        Acquire the lock guarding the configuration file.
+
+        Args:
+            None
+
+        Returns:
+            The acquired lock, which the caller is responsible for releasing.
+
+        Raises:
+            ConfigLockError: If the lock cannot be acquired, e.g., because the
+                filesystem hosting the configuration directory does not support
+                file locking.
+        """
+
+        lock_file = f"{self.config_file}.lock"
+        lock = filelock.FileLock(lock_file, timeout=CONFIG_LOCK_TIMEOUT)
+
+        try:
+            lock.acquire()
+        except (filelock.Timeout, NotImplementedError, OSError) as ex:
+            raise ConfigLockError(lock_file) from ex
+
+        return lock
 
     def read_config(self) -> None:
         """

--- a/covalent/_shared_files/exceptions.py
+++ b/covalent/_shared_files/exceptions.py
@@ -29,3 +29,21 @@ class TaskCancelledError(Exception):
 
 class CommandNotFoundError(Exception):
     pass
+
+
+class ConfigLockError(Exception):
+    """Raised when the lock on the Covalent configuration file cannot be acquired.
+
+    Attributes:
+        lock_file: Path of the lock file which could not be acquired.
+    """
+
+    def __init__(self, lock_file: str) -> None:
+        self.lock_file = lock_file
+        super().__init__(
+            f"Unable to acquire a lock on the Covalent configuration file '{lock_file}'. "
+            "Either another Covalent process is holding the lock, or the filesystem "
+            "hosting the configuration directory does not support file locking. Set the "
+            "COVALENT_CONFIG_DIR environment variable to a directory on a filesystem "
+            "which supports file locking, such as a local disk."
+        )

--- a/tests/covalent_tests/shared_files/config_test.py
+++ b/tests/covalent_tests/shared_files/config_test.py
@@ -26,6 +26,7 @@ from covalent._shared_files.exceptions import ConfigLockError
 
 DEFAULT_CONFIG = asdict(DefaultConfig())
 
+
 @pytest.fixture
 def config_manager():
     return ConfigManager()

--- a/tests/covalent_tests/shared_files/config_test.py
+++ b/tests/covalent_tests/shared_files/config_test.py
@@ -17,13 +17,14 @@
 import tempfile
 from dataclasses import asdict
 
+import filelock
 import pytest
 
 from covalent._shared_files.config import ConfigManager, get_config, reload_config, set_config
 from covalent._shared_files.defaults import DefaultConfig
+from covalent._shared_files.exceptions import ConfigLockError
 
 DEFAULT_CONFIG = asdict(DefaultConfig())
-
 
 @pytest.fixture
 def config_manager():
@@ -233,9 +234,33 @@ def test_update_config(mocker):
     cm.write_config.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "lock_error",
+    [filelock.Timeout("mock_config_file.lock"), NotImplementedError, OSError],
+)
+def test_update_config_lock_failure(mocker, lock_error):
+    """Test that an unacquirable config file lock raises an actionable error."""
+
+    cm = ConfigManager()
+
+    cm.config_file = "mock_config_file"
+
+    mock_filelock = mocker.patch("covalent._shared_files.config.filelock.FileLock")
+    mock_filelock.return_value.acquire.side_effect = lock_error
+    mock_open = mocker.patch("covalent._shared_files.config.open")
+
+    cm.write_config = mocker.Mock()
+
+    with pytest.raises(ConfigLockError, match="COVALENT_CONFIG_DIR"):
+        cm.update_config()
+
+    mock_open.assert_not_called()
+    cm.write_config.assert_not_called()
+    mock_filelock.return_value.release.assert_not_called()
+
+
 def test_config_manager_set(mocker, config_manager):
     """Test the set method in config manager."""
-
     cm = config_manager
     cm.config_data = {"mock_section": {"mock_dir": "initial_value"}}
     cm.set("mock_section.mock_dir", "final_value")


### PR DESCRIPTION
Fixes #1895

## Root cause

Config file lock failure surfaces as an opaque hang/`filelock` error at import time

## Changes

- Acquire the configuration file lock explicitly in `ConfigManager._acquire_config_lock` and translate lock-acquisition failures (`filelock.Timeout`, `NotImplementedError`, `OSError`) into a new `ConfigLockError` whose message names the lock file and tells the user to point `COVALENT_CONFIG_DIR` at a filesystem supporting file locking; the lock is released in a `finally` block. Added a parametrized regression test and a CHANGELOG entry.