### PR TITLE
fix: The `workdir` setting does not appear to work for the Dask/local executo...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed the `workdir` and `create_unique_workdir` settings being ignored by the local and Dask executors during managed execution; tasks now run in the configured working directory
 - Make `dask[distributed]` and optional dependency via `covalent[dask]` extra
 - Default executor changed from `dask` to `local` in `defaults.py`
 - Dropped Python 3.10 support, added Python 3.13; updated `test_matrix.json` and CI workflows accordingly

--- a/covalent/executor/executor_plugins/dask.py
+++ b/covalent/executor/executor_plugins/dask.py
@@ -268,9 +268,10 @@ class DaskExecutor(AsyncBaseExecutor):
             self.cache_dir,
             task_group_metadata,
             server_url,
+            self.workdir,
+            self.create_unique_workdir,
             key=key,
         )
-
         _clients[key] = dask_client
         _futures[key] = future
 

--- a/covalent/executor/executor_plugins/local.py
+++ b/covalent/executor/executor_plugins/local.py
@@ -184,6 +184,8 @@ class LocalExecutor(BaseExecutor):
             self.workdir,
             task_group_metadata,
             server_url,
+            self.workdir,
+            self.create_unique_workdir,
         )
 
         def handle_cancelled(fut):

--- a/covalent/executor/utils/wrappers.py
+++ b/covalent/executor/utils/wrappers.py
@@ -23,7 +23,7 @@ import json
 import os
 import sys
 import traceback
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple
 
@@ -96,6 +96,39 @@ def wrapper_fn(
     return TransportableObject(output)
 
 
+@contextmanager
+def set_workdir(workdir: str):
+    """Create the working directory and run the enclosed block inside it.
+
+    Args:
+        workdir: Directory in which the enclosed block is executed.
+    """
+    current_dir = os.getcwd()
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+    os.chdir(workdir)
+    try:
+        yield
+    finally:
+        os.chdir(current_dir)
+
+
+def task_workdir(workdir: str, create_unique_workdir: bool, dispatch_id: str, task_id: int) -> str:
+    """Resolve the working directory for a single task.
+
+    Args:
+        workdir: Base working directory.
+        create_unique_workdir: Whether each task gets its own subdirectory.
+        dispatch_id: Dispatch id of the task.
+        task_id: Node id of the task.
+
+    Returns:
+        The directory in which the task is to be executed.
+    """
+    if create_unique_workdir:
+        return os.path.join(workdir, dispatch_id, f"node_{task_id}")
+    return workdir
+
+
 def io_wrapper(
     fn: Callable,
     args: List,
@@ -106,16 +139,12 @@ def io_wrapper(
     process and capture stdout and stderr"""
     with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr:
         try:
-            Path(workdir).mkdir(parents=True, exist_ok=True)
-            current_dir = os.getcwd()
-            os.chdir(workdir)
-            output = fn(*args, **kwargs)
+            with set_workdir(workdir):
+                output = fn(*args, **kwargs)
             tb = ""
         except Exception as ex:
             output = None
             tb = "".join(traceback.TracebackException.from_exception(ex).format())
-        finally:
-            os.chdir(current_dir)
     return output, stdout.getvalue(), stderr.getvalue(), tb
 
 
@@ -161,6 +190,8 @@ def run_task_group(
     results_dir: str,
     task_group_metadata: dict,
     server_url: str,
+    workdir: str = ".",
+    create_unique_workdir: bool = False,
 ):
     """
     Run a task group.
@@ -243,7 +274,10 @@ def run_task_group(
                     )
                     exception_occurred = False
 
-                    with set_context(dispatch_id, task_id):
+                    current_workdir = task_workdir(
+                        workdir, create_unique_workdir, dispatch_id, task_id
+                    )
+                    with set_context(dispatch_id, task_id), set_workdir(current_workdir):
                         transportable_output = wrapper_fn(
                             serialized_fn, call_before, call_after, *ser_args, **ser_kwargs
                         )
@@ -351,6 +385,8 @@ def run_task_group_alt(
     results_dir: str,
     task_group_metadata: dict,
     server_url: str,
+    workdir: str = ".",
+    create_unique_workdir: bool = False,
 ):
     """
     Alternate form of run_task_group.
@@ -431,7 +467,10 @@ def run_task_group_alt(
                     exception_occurred = False
 
                     # Run the task function
-                    with set_context(dispatch_id, task_id):
+                    current_workdir = task_workdir(
+                        workdir, create_unique_workdir, dispatch_id, task_id
+                    )
+                    with set_context(dispatch_id, task_id), set_workdir(current_workdir):
                         transportable_output = wrapper_fn(
                             serialized_fn, call_before, call_after, *ser_args, **ser_kwargs
                         )

--- a/tests/covalent_tests/executor/executor_plugins/dask_test.py
+++ b/tests/covalent_tests/executor/executor_plugins/dask_test.py
@@ -373,10 +373,11 @@ def test_run_task_group_alt():
     """Test the wrapper submitted to dask"""
 
     def task(x, y):
+        with open("cwd.txt", "w") as f:
+            f.write(os.getcwd())
         return x + y
 
-    dispatch_id = "test_dask_send_receive"
-    node_id = 0
+    dispatch_id = "test_dask_send_receive"    node_id = 0
     task_group_id = 0
 
     x = TransportableObject(1)
@@ -446,23 +447,27 @@ def test_run_task_group_alt():
     stderr_file = tempfile.NamedTemporaryFile()
 
     results_dir = tempfile.TemporaryDirectory()
+    workdir = tempfile.TemporaryDirectory()
 
     run_task_group_alt(
-        task_specs=[task_spec.dict()],
-        resources=resources.dict(),
+        task_specs=[task_spec.dict()],        resources=resources.dict(),
         output_uris=[(result_file.name, stdout_file.name, stderr_file.name)],
         results_dir=results_dir.name,
         task_group_metadata=task_group_metadata,
         server_url="http://localhost:48008",
+        workdir=workdir.name,
+        create_unique_workdir=True,
     )
 
     with open(result_file.name, "rb") as f:
         output = TransportableObject.deserialize(f.read())
     assert output.get_deserialized() == 3
 
+    task_workdir = os.path.join(workdir.name, dispatch_id, f"node_{node_id}")
+    assert os.listdir(task_workdir) == ["cwd.txt"]
+
     with open(cb_tmpfile.name, "r") as f:
         assert f.read() == "Hello\n"
-
     with open(ca_tmpfile.name, "r") as f:
         assert f.read() == "Bye\n"
 

--- a/tests/covalent_tests/executor/executor_plugins/local_test.py
+++ b/tests/covalent_tests/executor/executor_plugins/local_test.py
@@ -243,10 +243,11 @@ def test_run_task_group(mocker):
     """Test the wrapper submitted to local"""
 
     def task(x, y):
+        with open("cwd.txt", "w") as f:
+            f.write(os.getcwd())
         return x + y
 
-    dispatch_id = "test_local_send_receive"
-    node_id = 0
+    dispatch_id = "test_local_send_receive"    node_id = 0
     task_group_id = 0
     server_url = "http://localhost:48008"
 
@@ -366,21 +367,25 @@ def test_run_task_group(mocker):
     stderr_file = tempfile.NamedTemporaryFile()
 
     results_dir = tempfile.TemporaryDirectory()
+    workdir = tempfile.TemporaryDirectory()
 
     run_task_group(
-        task_specs=[task_spec.dict()],
-        output_uris=[(result_file.name, stdout_file.name, stderr_file.name)],
+        task_specs=[task_spec.dict()],        output_uris=[(result_file.name, stdout_file.name, stderr_file.name)],
         results_dir=results_dir.name,
         task_group_metadata=task_group_metadata,
         server_url=server_url,
+        workdir=workdir.name,
+        create_unique_workdir=True,
     )
 
     output = TransportableObject.deserialize(resources[node_0_output_file_url])
     assert output.get_deserialized() == 3
 
+    task_workdir = os.path.join(workdir.name, dispatch_id, f"node_{node_id}")
+    assert os.listdir(task_workdir) == ["cwd.txt"]
+
     with open(cb_tmpfile.name, "r") as f:
         assert f.read() == "Hello\n"
-
     with open(ca_tmpfile.name, "r") as f:
         assert f.read() == "Bye\n"
 
@@ -640,8 +645,9 @@ def test_send_internal(
         local_exec.workdir,
         test_case["task_group_metadata"],
         test_case["expected_server_url"],
+        local_exec.workdir,
+        local_exec.create_unique_workdir,
     )
-
 
 @pytest.mark.asyncio
 async def test_send(mocker):


### PR DESCRIPTION
Fixes #1940

## Root cause

workdir ignored by managed-execution path of local/Dask executors

## Changes

- Thread `workdir`/`create_unique_workdir` through `run_task_group` and `run_task_group_alt` and execute the task function inside that directory via a new `set_workdir` context manager (also reused by `io_wrapper`, which previously raised UnboundLocalError if the workdir could not be created). Local and Dask executors now pass their configured workdir settings when submitting task groups; existing wrapper tests were extended to assert the task's CWD.